### PR TITLE
Release calendar now available on home page

### DIFF
--- a/clients/release_calendar/clients.go
+++ b/clients/release_calendar/clients.go
@@ -1,0 +1,92 @@
+package release_calendar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	rchttp "github.com/ONSdigital/dp-rchttp"
+	"github.com/ONSdigital/log.go/log"
+	"io/ioutil"
+	"net/http"
+)
+
+const service = "Babbage"
+
+// Client represents a zebedee client
+type Client struct {
+	cli rchttp.Clienter
+	url string
+}
+
+// ErrInvalidBabbageResponse is returned when the babbage service does not respond with a status 200
+type ErrInvalidBabbageResponse struct {
+	responseCode int
+}
+
+// Error should be called by the user to print out the stringified version of the error
+func (e ErrInvalidBabbageResponse) Error() string {
+	return fmt.Sprintf("invalid response from babbage service - status %d", e.responseCode)
+}
+
+// Code returns the status code received from renderer if an error is returned
+func (e ErrInvalidBabbageResponse) Code() int {
+	return e.responseCode
+}
+
+// New creates a new instance of Client with a given filter api url
+func New(babbageURL string) *Client {
+	hcClient := healthcheck.NewClient(service, babbageURL)
+
+	return &Client{
+		cli: hcClient.Client,
+		url: babbageURL,
+	}
+}
+
+// Checker calls dataset api health endpoint and returns a check object to the caller.
+func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
+	hcClient := healthcheck.Client{
+		Client: c.cli,
+		URL:    c.url,
+		Name:   service,
+	}
+
+	return hcClient.Checker(ctx, check)
+}
+
+func (c *Client) GetReleaseCalendar(ctx context.Context, userAccessToken, fromDay, fromMonth, fromYear string) (rc ReleaseCalendar, err error) {
+	reqURL := fmt.Sprintf("releasecalendar/data?fromDateDay=%s&fromDateMonth=%s&fromDateYear=%s)", fromDay, fromMonth, fromYear)
+	resp, err := c.get(ctx, reqURL)
+	if err != nil {
+		return rc, err
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return rc, ErrInvalidBabbageResponse{resp.StatusCode}
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(b, &rc)
+	return
+}
+
+func (c *Client) get(ctx context.Context, uri string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.cli.Do(ctx, req)
+}
+
+// closeResponseBody closes the response body and logs an error containing the context if unsuccessful
+func closeResponseBody(ctx context.Context, resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+	}
+}

--- a/clients/release_calendar/clients.go
+++ b/clients/release_calendar/clients.go
@@ -14,7 +14,7 @@ import (
 
 const service = "Babbage"
 
-// Client represents a zebedee client
+// Client represents a babbage client
 type Client struct {
 	cli rchttp.Clienter
 	url string
@@ -30,12 +30,12 @@ func (e ErrInvalidBabbageResponse) Error() string {
 	return fmt.Sprintf("invalid response from babbage service - status %d", e.responseCode)
 }
 
-// Code returns the status code received from renderer if an error is returned
+// Code returns the status code received from babbage if an error is returned
 func (e ErrInvalidBabbageResponse) Code() int {
 	return e.responseCode
 }
 
-// New creates a new instance of Client with a given filter api url
+// New creates a new instance of Client with a given babbage url
 func New(babbageURL string) *Client {
 	hcClient := healthcheck.NewClient(service, babbageURL)
 
@@ -45,7 +45,7 @@ func New(babbageURL string) *Client {
 	}
 }
 
-// Checker calls dataset api health endpoint and returns a check object to the caller.
+// Checker calls babbage health endpoint and returns a check object to the caller.
 func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
 	hcClient := healthcheck.Client{
 		Client: c.cli,
@@ -57,7 +57,7 @@ func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
 }
 
 func (c *Client) GetReleaseCalendar(ctx context.Context, userAccessToken, fromDay, fromMonth, fromYear string) (rc ReleaseCalendar, err error) {
-	reqURL := fmt.Sprintf(c.url + "/releasecalendar/data?fromDateDay=%s&fromDateMonth=%s&fromDateYear=%s)", fromDay, fromMonth, fromYear)
+	reqURL := fmt.Sprintf(c.url+"/releasecalendar/data?fromDateDay=%s&fromDateMonth=%s&fromDateYear=%s)", fromDay, fromMonth, fromYear)
 	resp, err := c.get(ctx, reqURL)
 	if err != nil {
 		return rc, err

--- a/clients/release_calendar/clients.go
+++ b/clients/release_calendar/clients.go
@@ -57,7 +57,7 @@ func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
 }
 
 func (c *Client) GetReleaseCalendar(ctx context.Context, userAccessToken, fromDay, fromMonth, fromYear string) (rc ReleaseCalendar, err error) {
-	reqURL := fmt.Sprintf("releasecalendar/data?fromDateDay=%s&fromDateMonth=%s&fromDateYear=%s)", fromDay, fromMonth, fromYear)
+	reqURL := fmt.Sprintf(c.url + "/releasecalendar/data?fromDateDay=%s&fromDateMonth=%s&fromDateYear=%s)", fromDay, fromMonth, fromYear)
 	resp, err := c.get(ctx, reqURL)
 	if err != nil {
 		return rc, err

--- a/clients/release_calendar/data.go
+++ b/clients/release_calendar/data.go
@@ -3,9 +3,9 @@ package release_calendar
 import "time"
 
 type ReleaseCalendar struct {
-	Type     string    `json:"type, omitempty"`
-	ListType string    `json:"listType, omitempty"`
-	URI      string    `json:"uri, omitempty"`
+	Type     string `json:"type, omitempty"`
+	ListType string `json:"listType, omitempty"`
+	URI      string `json:"uri, omitempty"`
 	Result   Result `json:"result"`
 }
 

--- a/clients/release_calendar/data.go
+++ b/clients/release_calendar/data.go
@@ -6,7 +6,7 @@ type ReleaseCalendar struct {
 	Type     string    `json:"type, omitempty"`
 	ListType string    `json:"listType, omitempty"`
 	URI      string    `json:"uri, omitempty"`
-	Result   *[]Result `json:"result"`
+	Result   Result `json:"result"`
 }
 
 type Result struct {
@@ -19,7 +19,7 @@ type Result struct {
 }
 
 type Results struct {
-	Type        string         `json:"_type"`
+	Type        string         `json:"type"`
 	Description *Descritpion   `json:"description"`
 	SearchBoost *[]interface{} `json:"searchBoost"`
 	URI         string         `json:"uri"`

--- a/clients/release_calendar/data.go
+++ b/clients/release_calendar/data.go
@@ -20,12 +20,12 @@ type Result struct {
 
 type Results struct {
 	Type        string         `json:"type"`
-	Description *Descritpion   `json:"description"`
+	Description *Description   `json:"description"`
 	SearchBoost *[]interface{} `json:"searchBoost"`
 	URI         string         `json:"uri"`
 }
 
-type Descritpion struct {
+type Description struct {
 	Summary            string    `json:"summary"`
 	NextRelease        string    `json:"nextRelease"`
 	ReleaseDate        time.Time `json:"releaseDate"`

--- a/clients/release_calendar/data.go
+++ b/clients/release_calendar/data.go
@@ -1,0 +1,49 @@
+package release_calendar
+
+import "time"
+
+type ReleaseCalendar struct {
+	Type     string    `json:"type, omitempty"`
+	ListType string    `json:"listType, omitempty"`
+	URI      string    `json:"uri, omitempty"`
+	Result   *[]Result `json:"result"`
+}
+
+type Result struct {
+	NumberOfResults int           `json:"numberOfResults"`
+	Took            int           `json:"took"`
+	Results         *[]Results    `json:"results"`
+	Suggestions     []interface{} `json:"suggestions"`
+	DocCounts       struct{}      `json:"docCounts"`
+	SortBy          string        `json:"sortBy"`
+}
+
+type Results struct {
+	Type        string         `json:"_type"`
+	Description *Descritpion   `json:"description"`
+	SearchBoost *[]interface{} `json:"searchBoost"`
+	URI         string         `json:"uri"`
+}
+
+type Descritpion struct {
+	Summary            string    `json:"summary"`
+	NextRelease        string    `json:"nextRelease"`
+	ReleaseDate        time.Time `json:"releaseDate"`
+	Finalised          bool      `json:"finalised"`
+	Source             string    `json:"source"`
+	Published          bool      `json:"published"`
+	Title              string    `json:"title"`
+	NationalStatistic  bool      `json:"nationalStatistic"`
+	Unit               string    `json:"unit"`
+	Contact            *Contact  `json:"contact"`
+	ProvisionalDate    string    `json:"provisionalDate"`
+	Cancelled          bool      `json:"cancelled"`
+	PreUnit            string    `json:"preUnit"`
+	CancellationNotice []string  `json:"cancellationNotice"`
+}
+
+type Contact struct {
+	Name      string `json:"name"`
+	Telephone string `json:"telephone"`
+	Email     string `json:"email"`
+}

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	RendererURL                string        `envconfig:"RENDERER_URL"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
+	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
 }
 
 var cfg *Config
@@ -32,6 +33,7 @@ func Get() (*Config, error) {
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		RendererURL:                "http://localhost:20010",
 		ZebedeeURL:                 "http://localhost:8082",
+		BabbageURL:                 "http://localhost:8080",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.RendererURL, ShouldEqual, "http://localhost:20010")
 				So(cfg.ZebedeeURL, ShouldEqual, "http://localhost:8082")
+				So(cfg.BabbageURL, ShouldEqual, "http://localhost:8080")
 			})
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gorilla/mux v1.7.4
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/matryer/moq v0.0.0-20191105074349-1206bf1e2aad // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.10.0
-	github.com/ONSdigital/dp-frontend-models v1.5.2
+	github.com/ONSdigital/dp-frontend-models v1.5.4
 	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/dp-rchttp v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/ONSdigital/dp-frontend-models v1.5.1 h1:L+DHGwt7Ujxwr8GgoPlV9BozOoi0x
 github.com/ONSdigital/dp-frontend-models v1.5.1/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.5.2 h1:tKkDGvaYSjP4kazsRLRNmXSdyrVMRzCnLh36ujmo6yE=
 github.com/ONSdigital/dp-frontend-models v1.5.2/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.5.4/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/ONSdigital/dp-frontend-models v1.5.1 h1:L+DHGwt7Ujxwr8GgoPlV9BozOoi0x
 github.com/ONSdigital/dp-frontend-models v1.5.1/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.5.2 h1:tKkDGvaYSjP4kazsRLRNmXSdyrVMRzCnLh36ujmo6yE=
 github.com/ONSdigital/dp-frontend-models v1.5.2/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.5.4 h1:aJDHnFgivyr1KvtE95kaPNn/de/19FMMQmLnfN+TGsk=
 github.com/ONSdigital/dp-frontend-models v1.5.4/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
@@ -58,6 +59,8 @@ github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/matryer/moq v0.0.0-20191105074349-1206bf1e2aad h1:ezt0XQSy84K4HO3G8PTGGk4fSnH/BDnUwyLMjJGthyo=
+github.com/matryer/moq v0.0.0-20191105074349-1206bf1e2aad/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
@@ -95,4 +98,5 @@ golang.org/x/sys v0.0.0-20200427175716-29b57079015a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/homepage/clients.go
+++ b/homepage/clients.go
@@ -1,0 +1,24 @@
+package homepage
+
+import (
+	"context"
+	"github.com/ONSdigital/dp-api-clients-go/zebedee"
+	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
+)
+
+//go:generate moq -out mocks_test.go -pkg homepage . ZebedeeClient RenderClient BabbageClient
+
+// ZebedeeClient is an interface with methods required for a zebedee client
+type ZebedeeClient interface {
+	GetTimeseriesMainFigure(ctx context.Context, userAuthToken, uri string) (m zebedee.TimeseriesMainFigure, err error)
+}
+
+// BabbageClient is an interface with methods required for a babbage client
+type BabbageClient interface {
+	GetReleaseCalendar(ctx context.Context, userAuthToken, dateFromDay, dateFromMonth, dateFromYear string) (m release_calendar.ReleaseCalendar, err error)
+}
+
+// RenderClient is an interface with methods for require for rendering a template
+type RenderClient interface {
+	Do(string, []byte) ([]byte, error)
+}

--- a/homepage/clients.go
+++ b/homepage/clients.go
@@ -18,7 +18,7 @@ type BabbageClient interface {
 	GetReleaseCalendar(ctx context.Context, userAuthToken, dateFromDay, dateFromMonth, dateFromYear string) (m release_calendar.ReleaseCalendar, err error)
 }
 
-// RenderClient is an interface with methods for require for rendering a template
+// RenderClient is an interface with methods required for rendering a template
 type RenderClient interface {
 	Do(string, []byte) ([]byte, error)
 }

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -55,7 +55,7 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 
 	userAccessToken, err := headers.GetUserAuthToken(req)
 	if err != nil {
-		log.Event(ctx, "unable to get user access token from header", log.WARN, log.Error(err))
+		log.Event(ctx, "unable to get user access token from header setting it to empty value", log.WARN, log.Error(err))
 		userAccessToken = ""
 	}
 
@@ -116,8 +116,11 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 		http.Error(w, "error rendering page", http.StatusInternalServerError)
 		return
 	}
-
-	w.Write(templateHTML)
+	if _, err := w.Write(templateHTML); err != nil {
+		log.Event(ctx, "failed to write response for homepage", log.ERROR, log.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	return
 }
 

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	"net/http"
 	"sync"
 	"time"
@@ -24,24 +23,6 @@ type MainFigure struct {
 }
 
 var mainFigureMap map[string]MainFigure
-
-//go:generate moq -out mocks_test.go -pkg homepage . ZebedeeClient RenderClient
-
-// ZebedeeClient is an interface with methods required for a zebedee client
-type ZebedeeClient interface {
-	GetTimeseriesMainFigure(ctx context.Context, userAuthToken, uri string) (m zebedee.TimeseriesMainFigure, err error)
-}
-
-// BabbageClient is an interface with methods required for a babbage client
-
-type BabbageClient interface {
-	GetReleaseCalendar(ctx context.Context, userAuthToken, dateFromDay, dateFromMonth, dateFromYear string) (m release_calendar.ReleaseCalendar, err error)
-}
-
-// RenderClient is an interface with methods for require for rendering a template
-type RenderClient interface {
-	Do(string, []byte) ([]byte, error)
-}
 
 // Handler handles requests to homepage endpoint
 func Handler(rend RenderClient, zcli ZebedeeClient, bcli BabbageClient) http.HandlerFunc {

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -100,7 +100,7 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	dateFromMonth := currentTime.Format("01")
 	dateFromYear := currentTime.Format("2006")
 	releaseCalResp, err := bcli.GetReleaseCalendar(ctx, userAccessToken, dateFromDay, dateFromMonth, dateFromYear)
-	releaseCalModelData := mapper.ReleaseCalendar(ctx, releaseCalResp)
+	releaseCalModelData := mapper.ReleaseCalendar(releaseCalResp)
 
 	if err != nil {
 		log.Event(ctx, "error getting timeseries data", log.Error(err))
@@ -110,7 +110,7 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	}
 
 
-	m := mapper.Homepage(ctx, localeCode, mappedMainFigures, releaseCalModelData)
+	m := mapper.Homepage(localeCode, mappedMainFigures, releaseCalModelData)
 
 	b, err := json.Marshal(m)
 	if err != nil {

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -99,7 +99,9 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	dateFromDay := currentTime.Format("02")
 	dateFromMonth := currentTime.Format("01")
 	dateFromYear := currentTime.Format("2006")
-	releaseCal, err := bcli.GetReleaseCalendar(ctx, userAccessToken, dateFromDay, dateFromMonth, dateFromYear)
+	releaseCalResp, err := bcli.GetReleaseCalendar(ctx, userAccessToken, dateFromDay, dateFromMonth, dateFromYear)
+	releaseCalModelData := mapper.ReleaseCalendar(ctx, releaseCalResp)
+
 	if err != nil {
 		log.Event(ctx, "error getting timeseries data", log.Error(err))
 		mappedErrorFigure := &model.MainFigure{ID: id}
@@ -108,7 +110,7 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	}
 
 
-	m := mapper.Homepage(ctx, localeCode, mappedMainFigures, releaseCal)
+	m := mapper.Homepage(ctx, localeCode, mappedMainFigures, releaseCalModelData)
 
 	b, err := json.Marshal(m)
 	if err != nil {

--- a/homepage/homepage_test.go
+++ b/homepage/homepage_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/gorilla/mux"
@@ -59,8 +60,79 @@ func TestUnitMapper(t *testing.T) {
 		URI: "test/uri/timeseries/456",
 	})
 
-	var mockedBabbageData release_calendar.ReleaseCalendar
-
+	mockedDescriptions := [5]*release_calendar.Description{
+		{
+			ReleaseDate: time.Now().AddDate(0,0,-1),
+			Cancelled: false,
+			Published: true,
+			Title: "Foo",
+		},{
+			ReleaseDate: time.Now().AddDate(0,0,-2),
+			Cancelled: false,
+			Published: true,
+			Title: "bAr",
+		},{
+			ReleaseDate: time.Now().AddDate(0,0,-3),
+			Cancelled: false,
+			Published: true,
+			Title: "BAZ",
+		},{
+			ReleaseDate: time.Now().AddDate(0,0,-4),
+			Cancelled: false,
+			Published: true,
+			Title: "qux",
+		},{
+			ReleaseDate: time.Now().AddDate(0,0,-5),
+			Cancelled: true,
+			Published: false,
+			Title: "Qu ux",
+		},
+	}
+	mockedResults := []release_calendar.Results{
+		{
+			Type: "release",
+			Description: mockedDescriptions[0],
+			SearchBoost: nil,
+			URI: "/releases/foo",
+		},
+		{
+			Type: "release",
+			Description: mockedDescriptions[1],
+			SearchBoost: nil,
+			URI: "/releases/bar",
+		},
+		{
+			Type: "release",
+			Description: mockedDescriptions[2],
+			SearchBoost: nil,
+			URI: "/releases/baz",
+		},
+		{
+			Type: "release",
+			Description: mockedDescriptions[3],
+			SearchBoost: nil,
+			URI: "/releases/qux",
+		},
+		{
+			Type: "release",
+			Description: mockedDescriptions[4],
+			SearchBoost: nil,
+			URI: "/releases/quux",
+		},
+	}
+	mockedBabbageRelease := release_calendar.ReleaseCalendar{
+		Type:     "list",
+		ListType: "releasecalendar",
+		URI:      "/releasecalendar/data",
+		Result:   release_calendar.Result{
+			NumberOfResults: 5,
+			Took:            3,
+			Results:         &mockedResults,
+			Suggestions:     nil,
+			DocCounts:       struct{}{},
+			SortBy:          "release_date",
+		},
+	}
 	expectedSuccessResponse := "<html><body><h1>Some HTML from renderer!</h1></body></html>"
 
 	Convey("test homepage handler", t, func() {
@@ -72,7 +144,7 @@ func TestUnitMapper(t *testing.T) {
 
 		mockBabbageClient := &BabbageClientMock{
 			GetReleaseCalendarFunc: func(ctx context.Context, userAuthToken, dateFromDay, dateFromMonth, dateFromYear string) (m release_calendar.ReleaseCalendar, err error) {
-				return mockedBabbageData, nil
+				return mockedBabbageRelease, nil
 			},
 		}
 

--- a/homepage/homepage_test.go
+++ b/homepage/homepage_test.go
@@ -2,6 +2,7 @@ package homepage
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,12 +59,20 @@ func TestUnitMapper(t *testing.T) {
 		URI: "test/uri/timeseries/456",
 	})
 
+	var mockedBabbageData release_calendar.ReleaseCalendar
+
 	expectedSuccessResponse := "<html><body><h1>Some HTML from renderer!</h1></body></html>"
 
 	Convey("test homepage handler", t, func() {
 		mockZebedeeClient := &ZebedeeClientMock{
 			GetTimeseriesMainFigureFunc: func(ctx context.Context, userAuthToken, uri string) (m zebedee.TimeseriesMainFigure, err error) {
 				return mockedZebedeeData[0], nil
+			},
+		}
+
+		mockBabbageClient := &BabbageClientMock{
+			GetReleaseCalendarFunc: func(ctx context.Context, userAuthToken, dateFromDay, dateFromMonth, dateFromYear string) (m release_calendar.ReleaseCalendar, err error) {
+				return mockedBabbageData, nil
 			},
 		}
 
@@ -77,7 +86,7 @@ func TestUnitMapper(t *testing.T) {
 		req.Header.Set("X-Florence-Token", "testuser")
 		rec := httptest.NewRecorder()
 		router := mux.NewRouter()
-		router.Path("/").HandlerFunc(Handler(mockRenderClient, mockZebedeeClient))
+		router.Path("/").HandlerFunc(Handler(mockRenderClient, mockZebedeeClient, mockBabbageClient))
 
 		Convey("returns 200 response", func() {
 			router.ServeHTTP(rec, req)

--- a/homepage/mocks_test.go
+++ b/homepage/mocks_test.go
@@ -6,6 +6,7 @@ package homepage
 import (
 	"context"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
+	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	"sync"
 )
 
@@ -160,5 +161,97 @@ func (mock *RenderClientMock) DoCalls() []struct {
 	lockRenderClientMockDo.RLock()
 	calls = mock.calls.Do
 	lockRenderClientMockDo.RUnlock()
+	return calls
+}
+
+var (
+	lockBabbageClientMockGetReleaseCalendar sync.RWMutex
+)
+
+// Ensure, that BabbageClientMock does implement BabbageClient.
+// If this is not the case, regenerate this file with moq.
+var _ BabbageClient = &BabbageClientMock{}
+
+// BabbageClientMock is a mock implementation of BabbageClient.
+//
+//     func TestSomethingThatUsesBabbageClient(t *testing.T) {
+//
+//         // make and configure a mocked BabbageClient
+//         mockedBabbageClient := &BabbageClientMock{
+//             GetReleaseCalendarFunc: func(ctx context.Context, userAuthToken string, dateFromDay string, dateFromMonth string, dateFromYear string) (release_calendar.ReleaseCalendar, error) {
+// 	               panic("mock out the GetReleaseCalendar method")
+//             },
+//         }
+//
+//         // use mockedBabbageClient in code that requires BabbageClient
+//         // and then make assertions.
+//
+//     }
+type BabbageClientMock struct {
+	// GetReleaseCalendarFunc mocks the GetReleaseCalendar method.
+	GetReleaseCalendarFunc func(ctx context.Context, userAuthToken string, dateFromDay string, dateFromMonth string, dateFromYear string) (release_calendar.ReleaseCalendar, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetReleaseCalendar holds details about calls to the GetReleaseCalendar method.
+		GetReleaseCalendar []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// UserAuthToken is the userAuthToken argument value.
+			UserAuthToken string
+			// DateFromDay is the dateFromDay argument value.
+			DateFromDay string
+			// DateFromMonth is the dateFromMonth argument value.
+			DateFromMonth string
+			// DateFromYear is the dateFromYear argument value.
+			DateFromYear string
+		}
+	}
+}
+
+// GetReleaseCalendar calls GetReleaseCalendarFunc.
+func (mock *BabbageClientMock) GetReleaseCalendar(ctx context.Context, userAuthToken string, dateFromDay string, dateFromMonth string, dateFromYear string) (release_calendar.ReleaseCalendar, error) {
+	if mock.GetReleaseCalendarFunc == nil {
+		panic("BabbageClientMock.GetReleaseCalendarFunc: method is nil but BabbageClient.GetReleaseCalendar was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		UserAuthToken string
+		DateFromDay   string
+		DateFromMonth string
+		DateFromYear  string
+	}{
+		Ctx:           ctx,
+		UserAuthToken: userAuthToken,
+		DateFromDay:   dateFromDay,
+		DateFromMonth: dateFromMonth,
+		DateFromYear:  dateFromYear,
+	}
+	lockBabbageClientMockGetReleaseCalendar.Lock()
+	mock.calls.GetReleaseCalendar = append(mock.calls.GetReleaseCalendar, callInfo)
+	lockBabbageClientMockGetReleaseCalendar.Unlock()
+	return mock.GetReleaseCalendarFunc(ctx, userAuthToken, dateFromDay, dateFromMonth, dateFromYear)
+}
+
+// GetReleaseCalendarCalls gets all the calls that were made to GetReleaseCalendar.
+// Check the length with:
+//     len(mockedBabbageClient.GetReleaseCalendarCalls())
+func (mock *BabbageClientMock) GetReleaseCalendarCalls() []struct {
+	Ctx           context.Context
+	UserAuthToken string
+	DateFromDay   string
+	DateFromMonth string
+	DateFromYear  string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		UserAuthToken string
+		DateFromDay   string
+		DateFromMonth string
+		DateFromYear  string
+	}
+	lockBabbageClientMockGetReleaseCalendar.RLock()
+	calls = mock.calls.GetReleaseCalendar
+	lockBabbageClientMockGetReleaseCalendar.RUnlock()
 	return calls
 }

--- a/main.go
+++ b/main.go
@@ -126,11 +126,11 @@ func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Re
 	if err = h.AddCheck("frontend renderer", r.Checker); err != nil {
 		log.Event(ctx, "failed to add frontend renderer checker", log.Error(err))
 	}
-	//if err = h.AddCheck("Zebedee", z.Checker); err != nil {
-	//	log.Event(ctx, "failed to add zebedee checker", log.Error(err))
-	//}
-	//if err = h.AddCheck("Babbage", b.Checker); err != nil {
-	//	log.Event(ctx, "failed to add babbage checker", log.Error(err))
-	//}
+	if err = h.AddCheck("Zebedee", z.Checker); err != nil {
+		log.Event(ctx, "failed to add zebedee checker", log.Error(err))
+	}
+	if err = h.AddCheck("Babbage", b.Checker); err != nil {
+		log.Event(ctx, "failed to add babbage checker", log.Error(err))
+	}
 	return
 }

--- a/main.go
+++ b/main.go
@@ -126,11 +126,11 @@ func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Re
 	if err = h.AddCheck("frontend renderer", r.Checker); err != nil {
 		log.Event(ctx, "failed to add frontend renderer checker", log.Error(err))
 	}
-	if err = h.AddCheck("Zebedee", z.Checker); err != nil {
-		log.Event(ctx, "failed to add zebedee checker", log.Error(err))
-	}
-	if err = h.AddCheck("Babbage", b.Checker); err != nil {
-		log.Event(ctx, "failed to add babbage checker", log.Error(err))
-	}
+	//if err = h.AddCheck("Zebedee", z.Checker); err != nil {
+	//	log.Event(ctx, "failed to add zebedee checker", log.Error(err))
+	//}
+	//if err = h.AddCheck("Babbage", b.Checker); err != nil {
+	//	log.Event(ctx, "failed to add babbage checker", log.Error(err))
+	//}
 	return
 }

--- a/main.go
+++ b/main.go
@@ -122,12 +122,12 @@ func gracefulShutdown(cfg *config.Config, s *server.Server, hc health.HealthChec
 	return nil
 }
 
-func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Renderer, z *zebedee.Client, b release_calendar.Client) (err error) {
+func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Renderer, z *zebedee.Client, b *release_calendar.Client) (err error) {
 	if err = h.AddCheck("frontend renderer", r.Checker); err != nil {
 		log.Event(ctx, "failed to add frontend renderer checker", log.Error(err))
 	}
 	if err = h.AddCheck("Zebedee", z.Checker); err != nil {
-		log.Event(ctx, "failed to add Zebedee checker", log.Error(err))
+		log.Event(ctx, "failed to add zebedee checker", log.Error(err))
 	}
 	if err = h.AddCheck("Babbage", b.Checker); err != nil {
 		log.Event(ctx, "failed to add babbage checker", log.Error(err))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -61,9 +61,17 @@ func MainFigure(ctx context.Context, id, datePeriod string, figure zebedee.Times
 }
 
 func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model.ReleaseCalendar {
+	releaseResults := *rawReleaseCalendar.Result.Results
+	numReleasesScheduled := rawReleaseCalendar.Result.NumberOfResults
+
+	for i := len(releaseResults) - 1; i >= 0; i-- {
+		if releaseResults[i].Description.Cancelled {
+			numReleasesScheduled--
+		}
+	}
 	rc := model.ReleaseCalendar{
-		Releases:         getLatestReleases(*rawReleaseCalendar.Result.Results),
-		NumberOfReleases: strconv.Itoa(rawReleaseCalendar.Result.NumberOfResults),
+		Releases:         getLatestReleases(releaseResults),
+		NumberOfReleases : strconv.Itoa(numReleasesScheduled),
 	}
 	return &rc
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -71,6 +71,13 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {
 	var latestReleases []model.Release
 
+	// Removed canceled releases
+	for i := len(rawReleases) - 1; i >= 0; i-- {
+		if rawReleases[i].Description.Cancelled {
+			rawReleases = append(rawReleases[:i], rawReleases[i+1:]...)
+		}
+	}
+
 	// Reverse order
 	sort.Slice(rawReleases, func(i, j int) bool {
 		return rawReleases[i].Description.ReleaseDate.After(rawReleases[j].Description.ReleaseDate)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"context"
 	"fmt"
+	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	"strconv"
 
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
@@ -12,7 +13,7 @@ import (
 )
 
 // Homepage maps data to our homepage frontend model
-func Homepage(ctx context.Context, localeCode string, mainFigures map[string]*model.MainFigure) model.Page {
+func Homepage(ctx context.Context, localeCode string, mainFigures map[string]*model.MainFigure, releaseCal release_calendar.ReleaseCalendar) model.Page {
 	var page model.Page
 	page.Type = "homepage"
 	page.Metadata.Title = "Home"

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Homepage maps data to our homepage frontend model
-func Homepage(ctx context.Context, localeCode string, mainFigures map[string]*model.MainFigure, releaseCal release_calendar.ReleaseCalendar) model.Page {
+func Homepage(ctx context.Context, localeCode string, mainFigures map[string]*model.MainFigure, releaseCal *model.ReleaseCalendar) model.Page {
 	var page model.Page
 	page.Type = "homepage"
 	page.Metadata.Title = "Home"
@@ -59,6 +59,10 @@ func MainFigure(ctx context.Context, id, datePeriod string, figure zebedee.Times
 	return &mf
 }
 
+func ReleaseCalendar(ctx context.Context, rawReleaseCalendar release_calendar.ReleaseCalendar) *model.ReleaseCalendar{
+	var rc model.ReleaseCalendar
+	return &rc
+}
 // getDataByPeriod returns the data for the time period set
 func getDataByPeriod(datePeriod string, data zebedee.TimeseriesMainFigure) []zebedee.TimeseriesDataPoint {
 	var mf []zebedee.TimeseriesDataPoint

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -65,13 +65,13 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 	numReleasesScheduled := rawReleaseCalendar.Result.NumberOfResults
 
 	for i := len(releaseResults) - 1; i >= 0; i-- {
-		if releaseResults[i].Description.Cancelled {
+		if releaseResults[i].Description.Cancelled || !releaseResults[i].Description.Published {
 			numReleasesScheduled--
 		}
 	}
 	rc := model.ReleaseCalendar{
 		Releases:         getLatestReleases(releaseResults),
-		NumberOfReleases : strconv.Itoa(numReleasesScheduled),
+		NumberOfReleases: strconv.Itoa(numReleasesScheduled),
 	}
 	return &rc
 }
@@ -79,9 +79,9 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {
 	var latestReleases []model.Release
 
-	// Removed canceled releases
+	// Removed canceled releases or unpublished releases
 	for i := len(rawReleases) - 1; i >= 0; i-- {
-		if rawReleases[i].Description.Cancelled {
+		if rawReleases[i].Description.Cancelled || !rawReleases[i].Description.Published {
 			rawReleases = append(rawReleases[:i], rawReleases[i+1:]...)
 		}
 	}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -90,7 +90,8 @@ func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {
 	sort.Slice(rawReleases, func(i, j int) bool {
 		return rawReleases[i].Description.ReleaseDate.After(rawReleases[j].Description.ReleaseDate)
 	})
-	for i := 0; i < 3; i++ {
+	displayedReleases := 3
+	for i := 0; i < displayedReleases; i++ {
 		if len(rawReleases)-1 >= i {
 			latestReleases = append(latestReleases, model.Release{
 				Title:       rawReleases[i].Description.Title,

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -71,27 +71,27 @@ func TestUnitMapper(t *testing.T) {
 	mockedMainFigures["test_id"] = &mockedMainFigure
 	mockedDescriptions := [5]*release_calendar.Description{
 		{
-			ReleaseDate: time.Now().AddDate(0,0,1),
+			ReleaseDate: time.Now().AddDate(0,0,-1),
 			Cancelled: false,
 			Published: true,
 			Title: "Foo",
 		},{
-			ReleaseDate: time.Now().AddDate(0,0,2),
+			ReleaseDate: time.Now().AddDate(0,0,-2),
 			Cancelled: false,
 			Published: true,
 			Title: "bAr",
 		},{
-			ReleaseDate: time.Now().AddDate(0,0,3),
+			ReleaseDate: time.Now().AddDate(0,0,-3),
 			Cancelled: false,
 			Published: true,
 			Title: "BAZ",
 		},{
-			ReleaseDate: time.Now().AddDate(0,0,4),
+			ReleaseDate: time.Now().AddDate(0,0,-4),
 			Cancelled: false,
 			Published: true,
 			Title: "qux",
 		},{
-			ReleaseDate: time.Now().AddDate(0,0,5),
+			ReleaseDate: time.Now().AddDate(0,0,-5),
 			Cancelled: true,
 			Published: false,
 			Title: "Qu ux",
@@ -102,31 +102,31 @@ func TestUnitMapper(t *testing.T) {
 			Type: "release",
 			Description: mockedDescriptions[0],
 			SearchBoost: nil,
-			URI: "releases/foo",
+			URI: "/releases/foo",
 		},
 		{
 			Type: "release",
 			Description: mockedDescriptions[1],
 			SearchBoost: nil,
-			URI: "releases/bar",
+			URI: "/releases/bar",
 		},
 		{
 			Type: "release",
 			Description: mockedDescriptions[2],
 			SearchBoost: nil,
-			URI: "releases/baz",
+			URI: "/releases/baz",
 		},
 		{
 			Type: "release",
 			Description: mockedDescriptions[3],
 			SearchBoost: nil,
-			URI: "releases/qux",
+			URI: "/releases/qux",
 		},
 		{
 			Type: "release",
 			Description: mockedDescriptions[4],
 			SearchBoost: nil,
-			URI: "releases/quux",
+			URI: "/releases/quux",
 		},
 	}
 	mockedBabbageRelease := release_calendar.ReleaseCalendar{
@@ -147,17 +147,17 @@ func TestUnitMapper(t *testing.T) {
 			{
 				Title: "Foo",
 				URI: "/releases/foo",
-				ReleaseDate:"",
+				ReleaseDate: time.Now().AddDate(0,0,-1).Format("01 January 2006"),
 			},
 			{
 				Title: "bAr",
 				URI: "/releases/bar",
-				ReleaseDate:"",
+				ReleaseDate: time.Now().AddDate(0,0,-2).Format("01 January 2006"),
 			},
 			{
 				Title: "BAZ",
 				URI: "/releases/baz",
-				ReleaseDate:"",
+				ReleaseDate: time.Now().AddDate(0,0,-3).Format("01 January 2006"),
 			},
 		},
 		NumberOfReleases: "4",
@@ -211,7 +211,7 @@ func TestUnitMapper(t *testing.T) {
 	})
 
 	Convey("test release calendar maps data correctly", t, func() {
-		So(ReleaseCalendar(mockedBabbageRelease), ShouldResemble, mockedReleaseData)
+		So(ReleaseCalendar(mockedBabbageRelease), ShouldResemble, &mockedReleaseData)
 	})
 
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 
 	"github.com/ONSdigital/dp-api-clients-go/renderer"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
@@ -12,9 +13,14 @@ import (
 	"github.com/gorilla/mux"
 )
 
+type Clients struct{
+	Renderer *renderer.Renderer
+	Zebedee *zebedee.Client
+	Babbage *release_calendar.Client
+}
 // Init initialises routes for the service
-func Init(ctx context.Context, r *mux.Router, hc health.HealthCheck, rend *renderer.Renderer, zcli *zebedee.Client) {
+func Init(ctx context.Context, r *mux.Router, hc health.HealthCheck, c Clients) {
 	log.Event(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
-	r.StrictSlash(true).Path("/").Methods("GET").HandlerFunc(homepage.Handler(rend, zcli))
+	r.StrictSlash(true).Path("/").Methods("GET").HandlerFunc(homepage.Handler(c.Renderer, c.Zebedee, c.Babbage))
 }


### PR DESCRIPTION
### What
- Health check for Babbage added
- Health check for Zebedee added
- New client for Release Calendar (to Babbage) added
- Clients in main.go passed to the routes is now in a single object to stop it getting too bulky as more and more clients are added
- New data structure for the release calendar to marshal to from Babbage
- Extended handler function to handle the release calendar information
- New mapping functions to map the release calendar to the frontend models
- Homepage mapping extended to include the release calendar
- UserAccessToken checking no longer logs out as an error if it isn't found - stops log spam when not in publishing

### How to review

This is still a WIP
- Tests are needed
- Proof of usage required - need to actually run it with the frontend systems

### Who can review

Anyone except me ... when ready which this is not yet
