### PR TITLE
Feature/featured content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/ONSdigital/dp-rchttp v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gorilla/mux v1.7.4
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-homepage-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.13.0
+	github.com/ONSdigital/dp-api-clients-go v1.13.1
 	github.com/ONSdigital/dp-cookies v0.1.0 // indirect
 	github.com/ONSdigital/dp-frontend-models v1.5.7
 	github.com/ONSdigital/dp-healthcheck v1.0.4

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ONSdigital/dp-rchttp v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gorilla/mux v1.7.4
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/ONSdigital/dp-frontend-homepage-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.10.0
+	github.com/ONSdigital/dp-api-clients-go v1.13.0
 	github.com/ONSdigital/dp-cookies v0.1.0 // indirect
-	github.com/ONSdigital/dp-frontend-models v1.5.6
-	github.com/ONSdigital/dp-healthcheck v1.0.3
+	github.com/ONSdigital/dp-frontend-models v1.5.7
+	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-rchttp v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/ONSdigital/dp-api-clients-go v1.10.0 h1:XfbnSO7iwC5u/1kjuJjJMcL3E4PRb
 github.com/ONSdigital/dp-api-clients-go v1.10.0/go.mod h1:JjxArqZjHzSZC9CGBAy/CQzw56fpk08oGvXgeuwQKnM=
 github.com/ONSdigital/dp-api-clients-go v1.13.0 h1:5vA5VWlMcezyOvFn2Zbi6lq0J2wajkg5V+lZtLkJCog=
 github.com/ONSdigital/dp-api-clients-go v1.13.0/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
+github.com/ONSdigital/dp-api-clients-go v1.13.1 h1:l44vosPVDwe6ht6BcBikRUBAkDFB5aqmHfFjZtKtn1U=
+github.com/ONSdigital/dp-api-clients-go v1.13.1/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/ONSdigital/dp-api-clients-go v1.9.1-0.20200429185509-b88d54406cbe h1:
 github.com/ONSdigital/dp-api-clients-go v1.9.1-0.20200429185509-b88d54406cbe/go.mod h1:JjxArqZjHzSZC9CGBAy/CQzw56fpk08oGvXgeuwQKnM=
 github.com/ONSdigital/dp-api-clients-go v1.10.0 h1:XfbnSO7iwC5u/1kjuJjJMcL3E4PRbWnpjiKTdf7ueWU=
 github.com/ONSdigital/dp-api-clients-go v1.10.0/go.mod h1:JjxArqZjHzSZC9CGBAy/CQzw56fpk08oGvXgeuwQKnM=
+github.com/ONSdigital/dp-api-clients-go v1.13.0 h1:5vA5VWlMcezyOvFn2Zbi6lq0J2wajkg5V+lZtLkJCog=
+github.com/ONSdigital/dp-api-clients-go v1.13.0/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
@@ -22,12 +24,18 @@ github.com/ONSdigital/dp-frontend-models v1.5.5 h1:a15CXDPsCqmaIC4mxBzwa6WBIql+d
 github.com/ONSdigital/dp-frontend-models v1.5.5/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.5.6 h1:PczSyRVst45I8YFjgYVwUaq6UBdUmy/e0J1eKnQ6ViY=
 github.com/ONSdigital/dp-frontend-models v1.5.6/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.5.7 h1:J7eNiZF33BWpR0/uWtJlXwsjEYK4vF8X3+9X0l6IECo=
+github.com/ONSdigital/dp-frontend-models v1.5.7/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.3 h1:wNA34U3uPD5t1SE8P3cbGqNZP4CUjyJFbSugPYgrBG0=
 github.com/ONSdigital/dp-healthcheck v1.0.3/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v1.0.4 h1:mR7y0zEULrq5oOYlrkJ3X8Z2nYdvu2TzQfueDCmCTl0=
+github.com/ONSdigital/dp-healthcheck v1.0.4/go.mod h1:9485FaCfhADi/jtudXVeaoBHMG/MoTTAibpFwovmSec=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
+github.com/ONSdigital/dp-net v1.0.2 h1:gVqTTchAmD4bj2C5592tiYc9NqrcMWnSVUGJ6jNHn40=
+github.com/ONSdigital/dp-net v1.0.2/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8 h1:MWIHCr/ud5ur9elhfvKtSjMJInqf3iUY8F4J27qGQPA=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
@@ -89,6 +97,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/homepage/clients.go
+++ b/homepage/clients.go
@@ -12,6 +12,7 @@ import (
 // ZebedeeClient is an interface with methods required for a zebedee client
 type ZebedeeClient interface {
 	GetTimeseriesMainFigure(ctx context.Context, userAuthToken, uri string) (m zebedee.TimeseriesMainFigure, err error)
+	GetHomepageContent(ctx context.Context, userAccessToken, path string) (m zebedee.HomepageContent, err error)
 }
 
 // BabbageClient is an interface with methods required for a babbage client

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -82,7 +82,13 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	releaseCalResp, err := bcli.GetReleaseCalendar(ctx, userAccessToken, dateFromDay, dateFromMonth, dateFromYear)
 	releaseCalModelData := mapper.ReleaseCalendar(releaseCalResp)
 
-	m := mapper.Homepage(localeCode, mappedMainFigures, releaseCalModelData)
+	// Get homepage data from Zebedee
+	homepageContent, err := zcli.GetHomepageContent(ctx, userAccessToken, HomepagePath)
+	if err != nil {
+		log.Event(ctx, "error getting homepage data", log.Error(err), log.Data{"content-path": HomepagePath})
+	}
+	mappedFeaturedContent := mapper.FeaturedContent(homepageContent)
+	m := mapper.Homepage(localeCode, mappedMainFigures, releaseCalModelData, mappedFeaturedContent)
 
 	b, err := json.Marshal(m)
 	if err != nil {
@@ -112,6 +118,8 @@ const (
 	PeriodQuarter = "quarter"
 	// PeriodMonth is the string value for month time period
 	PeriodMonth = "month"
+	// HomepagePath is the string value which contains the URI to get the homepage's data.json
+	HomepagePath = "/"
 )
 
 func init() {

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -85,9 +85,10 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	// Get homepage data from Zebedee
 	homepageContent, err := zcli.GetHomepageContent(ctx, userAccessToken, HomepagePath)
 	if err != nil {
-		log.Event(ctx, "error getting homepage data", log.Error(err), log.Data{"content-path": HomepagePath})
+		log.Event(ctx, "error getting homepage data from client", log.Error(err), log.Data{"content-path": HomepagePath})
 	}
 	mappedFeaturedContent := mapper.FeaturedContent(homepageContent)
+
 	m := mapper.Homepage(localeCode, mappedMainFigures, releaseCalModelData, &mappedFeaturedContent)
 
 	b, err := json.Marshal(m)

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -16,6 +16,17 @@ import (
 	"github.com/ONSdigital/log.go/log"
 )
 
+const (
+	// PeriodYear is the string value for year time period
+	PeriodYear = "year"
+	// PeriodQuarter is the string value for quarter time period
+	PeriodQuarter = "quarter"
+	// PeriodMonth is the string value for month time period
+	PeriodMonth = "month"
+	// HomepagePath is the string value which contains the URI to get the homepage's data.json
+	HomepagePath = "/"
+)
+
 type MainFigure struct {
 	uri        string
 	datePeriod string
@@ -111,17 +122,6 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	}
 	return
 }
-
-const (
-	// PeriodYear is the string value for year time period
-	PeriodYear = "year"
-	// PeriodQuarter is the string value for quarter time period
-	PeriodQuarter = "quarter"
-	// PeriodMonth is the string value for month time period
-	PeriodMonth = "month"
-	// HomepagePath is the string value which contains the URI to get the homepage's data.json
-	HomepagePath = "/"
-)
 
 func init() {
 	mainFigureMap = make(map[string]MainFigure)

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -88,7 +88,7 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 		log.Event(ctx, "error getting homepage data", log.Error(err), log.Data{"content-path": HomepagePath})
 	}
 	mappedFeaturedContent := mapper.FeaturedContent(homepageContent)
-	m := mapper.Homepage(localeCode, mappedMainFigures, releaseCalModelData, mappedFeaturedContent)
+	m := mapper.Homepage(localeCode, mappedMainFigures, releaseCalModelData, &mappedFeaturedContent)
 
 	b, err := json.Marshal(m)
 	if err != nil {

--- a/homepage/homepage_test.go
+++ b/homepage/homepage_test.go
@@ -144,7 +144,6 @@ func TestUnitMapper(t *testing.T) {
 				Title:       "Featured content one",
 				Description: "Featured content one description",
 				URI:         "Featured content one URI",
-				ImageURL:    "Featured content one imageURL",
 			},
 		},
 		ServiceMessage: "",

--- a/homepage/homepage_test.go
+++ b/homepage/homepage_test.go
@@ -146,31 +146,11 @@ func TestUnitMapper(t *testing.T) {
 				URI:         "Featured content one URI",
 				ImageURL:    "Featured content one imageURL",
 			},
-			{
-				Title:       "Featured content two",
-				Description: "Featured content two description",
-				URI:         "Featured content two URI",
-				ImageURL:    "Featured content two imageURL",
-			},
-			{
-				Title:       "Featured content three",
-				Description: "Featured content three description",
-				URI:         "Featured content three URI",
-				ImageURL:    "Featured content three imageURL",
-			},
 		},
 		ServiceMessage: "",
 		URI:            "/",
 		Type:           "",
-		Description: zebedee.HomepageDescription{
-			Title:           "Homepage description title",
-			Summary:         "Homepage description summary",
-			Keywords:        []string{"keyword one", "keyword two"},
-			MetaDescription: "",
-			Unit:            "",
-			PreUnit:         "",
-			Source:          "",
-		},
+		Description:    zebedee.HomepageDescription{},
 	}
 	expectedSuccessResponse := "<html><body><h1>Some HTML from renderer!</h1></body></html>"
 

--- a/homepage/homepage_test.go
+++ b/homepage/homepage_test.go
@@ -134,12 +134,53 @@ func TestUnitMapper(t *testing.T) {
 			SortBy:          "release_date",
 		},
 	}
+	mockedHomepageData := zebedee.HomepageContent{
+		Intro: zebedee.Intro{
+			Title:    "Welcome to the Office for National Statistics",
+			Markdown: "Markdown text here",
+		},
+		FeaturedContent: []zebedee.Featured{
+			{
+				Title:       "Featured content one",
+				Description: "Featured content one description",
+				URI:         "Featured content one URI",
+				ImageURL:    "Featured content one imageURL",
+			},
+			{
+				Title:       "Featured content two",
+				Description: "Featured content two description",
+				URI:         "Featured content two URI",
+				ImageURL:    "Featured content two imageURL",
+			},
+			{
+				Title:       "Featured content three",
+				Description: "Featured content three description",
+				URI:         "Featured content three URI",
+				ImageURL:    "Featured content three imageURL",
+			},
+		},
+		ServiceMessage: "",
+		URI:            "/",
+		Type:           "",
+		Description: zebedee.HomepageDescription{
+			Title:           "Homepage description title",
+			Summary:         "Homepage description summary",
+			Keywords:        []string{"keyword one", "keyword two"},
+			MetaDescription: "",
+			Unit:            "",
+			PreUnit:         "",
+			Source:          "",
+		},
+	}
 	expectedSuccessResponse := "<html><body><h1>Some HTML from renderer!</h1></body></html>"
 
 	Convey("test homepage handler", t, func() {
 		mockZebedeeClient := &ZebedeeClientMock{
 			GetTimeseriesMainFigureFunc: func(ctx context.Context, userAuthToken, uri string) (m zebedee.TimeseriesMainFigure, err error) {
 				return mockedZebedeeData[0], nil
+			},
+			GetHomepageContentFunc: func(ctx context.Context, userAuthToken, uri string) (m zebedee.HomepageContent, err error) {
+				return mockedHomepageData, nil
 			},
 		}
 

--- a/homepage/mocks_test.go
+++ b/homepage/mocks_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var (
+	lockZebedeeClientMockGetHomepageContent      sync.RWMutex
 	lockZebedeeClientMockGetTimeseriesMainFigure sync.RWMutex
 )
 
@@ -24,6 +25,9 @@ var _ ZebedeeClient = &ZebedeeClientMock{}
 //
 //         // make and configure a mocked ZebedeeClient
 //         mockedZebedeeClient := &ZebedeeClientMock{
+//             GetHomepageContentFunc: func(ctx context.Context, userAccessToken string, path string) (zebedee.HomepageContent, error) {
+// 	               panic("mock out the GetHomepageContent method")
+//             },
 //             GetTimeseriesMainFigureFunc: func(ctx context.Context, userAuthToken string, uri string) (zebedee.TimeseriesMainFigure, error) {
 // 	               panic("mock out the GetTimeseriesMainFigure method")
 //             },
@@ -34,11 +38,23 @@ var _ ZebedeeClient = &ZebedeeClientMock{}
 //
 //     }
 type ZebedeeClientMock struct {
+	// GetHomepageContentFunc mocks the GetHomepageContent method.
+	GetHomepageContentFunc func(ctx context.Context, userAccessToken string, path string) (zebedee.HomepageContent, error)
+
 	// GetTimeseriesMainFigureFunc mocks the GetTimeseriesMainFigure method.
 	GetTimeseriesMainFigureFunc func(ctx context.Context, userAuthToken string, uri string) (zebedee.TimeseriesMainFigure, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// GetHomepageContent holds details about calls to the GetHomepageContent method.
+		GetHomepageContent []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// UserAccessToken is the userAccessToken argument value.
+			UserAccessToken string
+			// Path is the path argument value.
+			Path string
+		}
 		// GetTimeseriesMainFigure holds details about calls to the GetTimeseriesMainFigure method.
 		GetTimeseriesMainFigure []struct {
 			// Ctx is the ctx argument value.
@@ -49,6 +65,45 @@ type ZebedeeClientMock struct {
 			URI string
 		}
 	}
+}
+
+// GetHomepageContent calls GetHomepageContentFunc.
+func (mock *ZebedeeClientMock) GetHomepageContent(ctx context.Context, userAccessToken string, path string) (zebedee.HomepageContent, error) {
+	if mock.GetHomepageContentFunc == nil {
+		panic("ZebedeeClientMock.GetHomepageContentFunc: method is nil but ZebedeeClient.GetHomepageContent was just called")
+	}
+	callInfo := struct {
+		Ctx             context.Context
+		UserAccessToken string
+		Path            string
+	}{
+		Ctx:             ctx,
+		UserAccessToken: userAccessToken,
+		Path:            path,
+	}
+	lockZebedeeClientMockGetHomepageContent.Lock()
+	mock.calls.GetHomepageContent = append(mock.calls.GetHomepageContent, callInfo)
+	lockZebedeeClientMockGetHomepageContent.Unlock()
+	return mock.GetHomepageContentFunc(ctx, userAccessToken, path)
+}
+
+// GetHomepageContentCalls gets all the calls that were made to GetHomepageContent.
+// Check the length with:
+//     len(mockedZebedeeClient.GetHomepageContentCalls())
+func (mock *ZebedeeClientMock) GetHomepageContentCalls() []struct {
+	Ctx             context.Context
+	UserAccessToken string
+	Path            string
+} {
+	var calls []struct {
+		Ctx             context.Context
+		UserAccessToken string
+		Path            string
+	}
+	lockZebedeeClientMockGetHomepageContent.RLock()
+	calls = mock.calls.GetHomepageContent
+	lockZebedeeClientMockGetHomepageContent.RUnlock()
+	return calls
 }
 
 // GetTimeseriesMainFigure calls GetTimeseriesMainFigureFunc.
@@ -87,80 +142,6 @@ func (mock *ZebedeeClientMock) GetTimeseriesMainFigureCalls() []struct {
 	lockZebedeeClientMockGetTimeseriesMainFigure.RLock()
 	calls = mock.calls.GetTimeseriesMainFigure
 	lockZebedeeClientMockGetTimeseriesMainFigure.RUnlock()
-	return calls
-}
-
-var (
-	lockRenderClientMockDo sync.RWMutex
-)
-
-// Ensure, that RenderClientMock does implement RenderClient.
-// If this is not the case, regenerate this file with moq.
-var _ RenderClient = &RenderClientMock{}
-
-// RenderClientMock is a mock implementation of RenderClient.
-//
-//     func TestSomethingThatUsesRenderClient(t *testing.T) {
-//
-//         // make and configure a mocked RenderClient
-//         mockedRenderClient := &RenderClientMock{
-//             DoFunc: func(in1 string, in2 []byte) ([]byte, error) {
-// 	               panic("mock out the Do method")
-//             },
-//         }
-//
-//         // use mockedRenderClient in code that requires RenderClient
-//         // and then make assertions.
-//
-//     }
-type RenderClientMock struct {
-	// DoFunc mocks the Do method.
-	DoFunc func(in1 string, in2 []byte) ([]byte, error)
-
-	// calls tracks calls to the methods.
-	calls struct {
-		// Do holds details about calls to the Do method.
-		Do []struct {
-			// In1 is the in1 argument value.
-			In1 string
-			// In2 is the in2 argument value.
-			In2 []byte
-		}
-	}
-}
-
-// Do calls DoFunc.
-func (mock *RenderClientMock) Do(in1 string, in2 []byte) ([]byte, error) {
-	if mock.DoFunc == nil {
-		panic("RenderClientMock.DoFunc: method is nil but RenderClient.Do was just called")
-	}
-	callInfo := struct {
-		In1 string
-		In2 []byte
-	}{
-		In1: in1,
-		In2: in2,
-	}
-	lockRenderClientMockDo.Lock()
-	mock.calls.Do = append(mock.calls.Do, callInfo)
-	lockRenderClientMockDo.Unlock()
-	return mock.DoFunc(in1, in2)
-}
-
-// DoCalls gets all the calls that were made to Do.
-// Check the length with:
-//     len(mockedRenderClient.DoCalls())
-func (mock *RenderClientMock) DoCalls() []struct {
-	In1 string
-	In2 []byte
-} {
-	var calls []struct {
-		In1 string
-		In2 []byte
-	}
-	lockRenderClientMockDo.RLock()
-	calls = mock.calls.Do
-	lockRenderClientMockDo.RUnlock()
 	return calls
 }
 
@@ -253,5 +234,79 @@ func (mock *BabbageClientMock) GetReleaseCalendarCalls() []struct {
 	lockBabbageClientMockGetReleaseCalendar.RLock()
 	calls = mock.calls.GetReleaseCalendar
 	lockBabbageClientMockGetReleaseCalendar.RUnlock()
+	return calls
+}
+
+var (
+	lockRenderClientMockDo sync.RWMutex
+)
+
+// Ensure, that RenderClientMock does implement RenderClient.
+// If this is not the case, regenerate this file with moq.
+var _ RenderClient = &RenderClientMock{}
+
+// RenderClientMock is a mock implementation of RenderClient.
+//
+//     func TestSomethingThatUsesRenderClient(t *testing.T) {
+//
+//         // make and configure a mocked RenderClient
+//         mockedRenderClient := &RenderClientMock{
+//             DoFunc: func(in1 string, in2 []byte) ([]byte, error) {
+// 	               panic("mock out the Do method")
+//             },
+//         }
+//
+//         // use mockedRenderClient in code that requires RenderClient
+//         // and then make assertions.
+//
+//     }
+type RenderClientMock struct {
+	// DoFunc mocks the Do method.
+	DoFunc func(in1 string, in2 []byte) ([]byte, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Do holds details about calls to the Do method.
+		Do []struct {
+			// In1 is the in1 argument value.
+			In1 string
+			// In2 is the in2 argument value.
+			In2 []byte
+		}
+	}
+}
+
+// Do calls DoFunc.
+func (mock *RenderClientMock) Do(in1 string, in2 []byte) ([]byte, error) {
+	if mock.DoFunc == nil {
+		panic("RenderClientMock.DoFunc: method is nil but RenderClient.Do was just called")
+	}
+	callInfo := struct {
+		In1 string
+		In2 []byte
+	}{
+		In1: in1,
+		In2: in2,
+	}
+	lockRenderClientMockDo.Lock()
+	mock.calls.Do = append(mock.calls.Do, callInfo)
+	lockRenderClientMockDo.Unlock()
+	return mock.DoFunc(in1, in2)
+}
+
+// DoCalls gets all the calls that were made to Do.
+// Check the length with:
+//     len(mockedRenderClient.DoCalls())
+func (mock *RenderClientMock) DoCalls() []struct {
+	In1 string
+	In2 []byte
+} {
+	var calls []struct {
+		In1 string
+		In2 []byte
+	}
+	lockRenderClientMockDo.RLock()
+	calls = mock.calls.Do
+	lockRenderClientMockDo.RUnlock()
 	return calls
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -84,12 +84,11 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 // FeaturedContent takes the homepageContent as returned from the client and returns an array of featured content
 func FeaturedContent(homepageData zebedee.HomepageContent) []model.Feature {
 	var mappedFeaturesArray []model.Feature
-	for i := 0; i < len(homepageData.FeaturedContent); i++ {
+	for _, fc := range homepageData.FeaturedContent {
 		mappedFeaturesArray = append(mappedFeaturesArray, model.Feature{
-			Title:       homepageData.FeaturedContent[i].Title,
-			Description: homepageData.FeaturedContent[i].Description,
-			URI:         homepageData.FeaturedContent[i].URI,
-			ImageURL:    homepageData.FeaturedContent[i].ImageURL,
+			Title:       fc.Title,
+			Description: fc.Description,
+			URI:         fc.URI,
 		})
 	}
 	return mappedFeaturesArray

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -83,15 +83,15 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 
 // FeaturedContent takes the homepageContent as returned from the client and returns an array of featured content
 func FeaturedContent(homepageData zebedee.HomepageContent) []model.Feature {
-	var mappedFeaturesArray []model.Feature
+	var mappedFeaturesContent []model.Feature
 	for _, fc := range homepageData.FeaturedContent {
-		mappedFeaturesArray = append(mappedFeaturesArray, model.Feature{
+		mappedFeaturesContent = append(mappedFeaturesContent, model.Feature{
 			Title:       fc.Title,
 			Description: fc.Description,
 			URI:         fc.URI,
 		})
 	}
-	return mappedFeaturesArray
+	return mappedFeaturesContent
 }
 
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -14,13 +14,14 @@ import (
 )
 
 // Homepage maps data to our homepage frontend model
-func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, releaseCal *model.ReleaseCalendar) model.Page {
+func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, releaseCal *model.ReleaseCalendar, featuredContent *[]model.Feature) model.Page {
 	var page model.Page
 	page.Type = "homepage"
 	page.Metadata.Title = "Home"
 	page.Language = localeCode
 	page.Data.MainFigures = mainFigures
 	page.Data.ReleaseCalendar = *releaseCal
+	page.Data.Featured = *featuredContent
 	return page
 }
 
@@ -78,6 +79,20 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 		NumberOfOtherReleasesInSevenDays: numReleasesScheduled - len(latestReleases),
 	}
 	return &rc
+}
+
+// FeaturedContent takes the homepageContent as returned from the client and returns an array of featured content
+func FeaturedContent(homepageData zebedee.HomepageContent) *[]model.Feature {
+	var mappedFeaturesArray []model.Feature
+	for i := 0; i < len(homepageData.FeaturedContent); i++ {
+		mappedFeaturesArray = append(mappedFeaturesArray, model.Feature{
+			Title:       homepageData.FeaturedContent[i].Title,
+			Description: homepageData.FeaturedContent[i].Description,
+			URI:         homepageData.FeaturedContent[i].URI,
+			ImageURL:    homepageData.FeaturedContent[i].ImageURL,
+		})
+	}
+	return &mappedFeaturesArray
 }
 
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -82,7 +82,7 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 }
 
 // FeaturedContent takes the homepageContent as returned from the client and returns an array of featured content
-func FeaturedContent(homepageData zebedee.HomepageContent) *[]model.Feature {
+func FeaturedContent(homepageData zebedee.HomepageContent) []model.Feature {
 	var mappedFeaturesArray []model.Feature
 	for i := 0; i < len(homepageData.FeaturedContent); i++ {
 		mappedFeaturesArray = append(mappedFeaturesArray, model.Feature{
@@ -92,7 +92,7 @@ func FeaturedContent(homepageData zebedee.HomepageContent) *[]model.Feature {
 			ImageURL:    homepageData.FeaturedContent[i].ImageURL,
 		})
 	}
-	return &mappedFeaturesArray
+	return mappedFeaturesArray
 }
 
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -230,6 +230,7 @@ func TestUnitMapper(t *testing.T) {
 		So(page.Data.MainFigures["test_id"].Figure, ShouldEqual, mockedMainFigure.Figure)
 		So(page.Data.MainFigures["test_id"].TrendDescription, ShouldEqual, mockedMainFigure.TrendDescription)
 		So(page.Data.MainFigures["test_id"].Trend, ShouldResemble, mockedMainFigure.Trend)
+		So(len(page.Data.Featured), ShouldEqual, 3)
 	})
 
 	Convey("test main figures mapping works", t, func() {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -174,19 +174,19 @@ func TestUnitMapper(t *testing.T) {
 				Title:       "Featured content one",
 				Description: "Featured content one description",
 				URI:         "Featured content one URI",
-				ImageURL:    "Featured content one imageURL",
+				ImageID:     "1-id",
 			},
 			{
 				Title:       "Featured content two",
 				Description: "Featured content two description",
 				URI:         "Featured content two URI",
-				ImageURL:    "Featured content two imageURL",
+				ImageID:     "2-id",
 			},
 			{
 				Title:       "Featured content three",
 				Description: "Featured content three description",
 				URI:         "Featured content three URI",
-				ImageURL:    "Featured content three imageURL",
+				ImageID:     "3-id",
 			},
 		},
 		ServiceMessage: "",
@@ -207,19 +207,19 @@ func TestUnitMapper(t *testing.T) {
 			Title:       "Featured content one",
 			Description: "Featured content one description",
 			URI:         "Featured content one URI",
-			ImageURL:    "Featured content one imageURL",
+			ImageURL:    "/1-id.svg",
 		},
 		{
 			Title:       "Featured content two",
 			Description: "Featured content two description",
 			URI:         "Featured content two URI",
-			ImageURL:    "Featured content two imageURL",
+			ImageURL:    "/2-id.svg",
 		},
 		{
 			Title:       "Featured content three",
 			Description: "Featured content three description",
 			URI:         "Featured content three URI",
-			ImageURL:    "Featured content three imageURL",
+			ImageURL:    "/3-id.svg",
 		},
 	}
 
@@ -261,7 +261,6 @@ func TestUnitMapper(t *testing.T) {
 				So(featuredContent[i].Title, ShouldEqual, mockedTestData.FeaturedContent[i].Title)
 				So(featuredContent[i].Description, ShouldEqual, mockedTestData.FeaturedContent[i].Description)
 				So(featuredContent[i].URI, ShouldEqual, mockedTestData.FeaturedContent[i].URI)
-				So(featuredContent[i].ImageURL, ShouldEqual, mockedTestData.FeaturedContent[i].ImageURL)
 			}
 		})
 	})

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -245,16 +245,24 @@ func TestUnitMapper(t *testing.T) {
 		So(mainFigures.Unit, ShouldEqual, "%")
 	})
 
-	Convey("test featured content mapping aligns with expectations", t, func() {
-		mockedTestData := mockedHomepageData
-		featuredContent := FeaturedContent(mockedTestData)
-		So(len(featuredContent), ShouldEqual, 3)
-		for i := 0; i < len(featuredContent); i++ {
-			So(featuredContent[i].Title, ShouldEqual, mockedTestData.FeaturedContent[i].Title)
-			So(featuredContent[i].Description, ShouldEqual, mockedTestData.FeaturedContent[i].Description)
-			So(featuredContent[i].URI, ShouldEqual, mockedTestData.FeaturedContent[i].URI)
-			So(featuredContent[i].ImageURL, ShouldEqual, mockedTestData.FeaturedContent[i].ImageURL)
-		}
+	Convey("test FeaturedContent", t, func() {
+		Convey("FeaturedContent handles when no homepage data is passed in", func() {
+			mockedTestData := zebedee.HomepageContent{}
+			featuredContent := FeaturedContent(mockedTestData)
+			So(featuredContent, ShouldBeNil)
+		})
+
+		Convey("FeaturedContent maps mock data to page model correctly", func() {
+			mockedTestData := mockedHomepageData
+			featuredContent := FeaturedContent(mockedTestData)
+			So(len(featuredContent), ShouldEqual, 3)
+			for i := 0; i < len(featuredContent); i++ {
+				So(featuredContent[i].Title, ShouldEqual, mockedTestData.FeaturedContent[i].Title)
+				So(featuredContent[i].Description, ShouldEqual, mockedTestData.FeaturedContent[i].Description)
+				So(featuredContent[i].URI, ShouldEqual, mockedTestData.FeaturedContent[i].URI)
+				So(featuredContent[i].ImageURL, ShouldEqual, mockedTestData.FeaturedContent[i].ImageURL)
+			}
+		})
 	})
 
 	Convey("test getDataByPeriod returns correct data struct", t, func() {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -164,9 +164,67 @@ func TestUnitMapper(t *testing.T) {
 		NumberOfReleases:                 4,
 		NumberOfOtherReleasesInSevenDays: 1,
 	}
+	var mockedHomepageData = zebedee.HomepageContent{
+		Intro: zebedee.Intro{
+			Title:    "Welcome to the Office for National Statistics",
+			Markdown: "Markdown text here",
+		},
+		FeaturedContent: []zebedee.Featured{
+			{
+				Title:       "Featured content one",
+				Description: "Featured content one description",
+				URI:         "Featured content one URI",
+				ImageURL:    "Featured content one imageURL",
+			},
+			{
+				Title:       "Featured content two",
+				Description: "Featured content two description",
+				URI:         "Featured content two URI",
+				ImageURL:    "Featured content two imageURL",
+			},
+			{
+				Title:       "Featured content three",
+				Description: "Featured content three description",
+				URI:         "Featured content three URI",
+				ImageURL:    "Featured content three imageURL",
+			},
+		},
+		ServiceMessage: "",
+		URI:            "/",
+		Type:           "",
+		Description: zebedee.HomepageDescription{
+			Title:           "Homepage description title",
+			Summary:         "Homepage description summary",
+			Keywords:        []string{"keyword one", "keyword two"},
+			MetaDescription: "",
+			Unit:            "",
+			PreUnit:         "",
+			Source:          "",
+		},
+	}
+	var mockedFeaturedContent = []model.Feature{
+		{
+			Title:       "Featured content one",
+			Description: "Featured content one description",
+			URI:         "Featured content one URI",
+			ImageURL:    "Featured content one imageURL",
+		},
+		{
+			Title:       "Featured content two",
+			Description: "Featured content two description",
+			URI:         "Featured content two URI",
+			ImageURL:    "Featured content two imageURL",
+		},
+		{
+			Title:       "Featured content three",
+			Description: "Featured content three description",
+			URI:         "Featured content three URI",
+			ImageURL:    "Featured content three imageURL",
+		},
+	}
 
 	Convey("test homepage mapping works", t, func() {
-		page := Homepage("en", mockedMainFigures, &mockedReleaseData)
+		page := Homepage("en", mockedMainFigures, &mockedReleaseData, &mockedFeaturedContent)
 
 		So(page.Type, ShouldEqual, "homepage")
 		So(page.Data.MainFigures["test_id"].Figure, ShouldEqual, mockedMainFigure.Figure)
@@ -185,6 +243,18 @@ func TestUnitMapper(t *testing.T) {
 		So(mainFigures.FigureURIs.Analysis, ShouldEqual, "test/uri/timeseries/123")
 		So(mainFigures.FigureURIs.Data, ShouldEqual, "test/uri/timeseries/456")
 		So(mainFigures.Unit, ShouldEqual, "%")
+	})
+
+	Convey("test featured content mapping aligns with expectations", t, func() {
+		mockedTestData := mockedHomepageData
+		featuredContent := FeaturedContent(mockedTestData)
+		So(len(featuredContent), ShouldEqual, 3)
+		for i := 0; i < len(featuredContent); i++ {
+			So(featuredContent[i].Title, ShouldEqual, mockedTestData.FeaturedContent[i].Title)
+			So(featuredContent[i].Description, ShouldEqual, mockedTestData.FeaturedContent[i].Description)
+			So(featuredContent[i].URI, ShouldEqual, mockedTestData.FeaturedContent[i].URI)
+			So(featuredContent[i].ImageURL, ShouldEqual, mockedTestData.FeaturedContent[i].ImageURL)
+		}
 	})
 
 	Convey("test getDataByPeriod returns correct data struct", t, func() {


### PR DESCRIPTION
### What

This PR covers the process of mapping homepage data fetched via the Zebedee Client into the page model for the Renderer to use.

Specifically, this PR:
- Bumps `dp-healthcheck`, `dp-frontend-models` and `dp-api-clients-go` versions
- Updates to the ZebedeeClient interface to take the new method added to the client (`GetHomepageContent`) - mocks generated by `moq` updated accordingly
- Implement fetch request to retrieve data via the client
- Added new mapper function to handle mapping data retrieved via the client into the page model for the renderer
- Test cases to cover new code additions

### How to review

- Ensure tests added are sensible cases and pass
- Review code changes make sense

### Who can review

Anyone but me
