### PR TITLE
Feature/image api client mapping

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	RendererURL                string        `envconfig:"RENDERER_URL"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
 	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
+	ImageURL                   string        `envconfig:"IMAGE_URL"`
 }
 
 var cfg *Config
@@ -34,6 +35,7 @@ func Get() (*Config, error) {
 		RendererURL:                "http://localhost:20010",
 		ZebedeeURL:                 "http://localhost:8082",
 		BabbageURL:                 "http://localhost:8080",
+		ImageURL:                   "http://localhost:24700",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/homepage/clients.go
+++ b/homepage/clients.go
@@ -3,6 +3,7 @@ package homepage
 import (
 	"context"
 
+	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 )
@@ -18,6 +19,11 @@ type ZebedeeClient interface {
 // BabbageClient is an interface with methods required for a babbage client
 type BabbageClient interface {
 	GetReleaseCalendar(ctx context.Context, userAccessToken, fromDay, fromMonth, fromYear string) (m release_calendar.ReleaseCalendar, err error)
+}
+
+// ImageClient is an interface with methods required for the Image API service client
+type ImageClient interface {
+	GetImage(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, imageID string) (m image.Image, err error)
 }
 
 // RenderClient is an interface with methods required for rendering a template

--- a/homepage/mocks_test.go
+++ b/homepage/mocks_test.go
@@ -5,6 +5,7 @@ package homepage
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	"sync"
@@ -234,6 +235,98 @@ func (mock *BabbageClientMock) GetReleaseCalendarCalls() []struct {
 	lockBabbageClientMockGetReleaseCalendar.RLock()
 	calls = mock.calls.GetReleaseCalendar
 	lockBabbageClientMockGetReleaseCalendar.RUnlock()
+	return calls
+}
+
+var (
+	lockImageClientMockGetImage sync.RWMutex
+)
+
+// Ensure, that ImageClientMock does implement ImageClient.
+// If this is not the case, regenerate this file with moq.
+var _ ImageClient = &ImageClientMock{}
+
+// ImageClientMock is a mock implementation of ImageClient.
+//
+//     func TestSomethingThatUsesImageClient(t *testing.T) {
+//
+//         // make and configure a mocked ImageClient
+//         mockedImageClient := &ImageClientMock{
+//             GetImageFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, imageID string) (image.Image, error) {
+// 	               panic("mock out the GetImage method")
+//             },
+//         }
+//
+//         // use mockedImageClient in code that requires ImageClient
+//         // and then make assertions.
+//
+//     }
+type ImageClientMock struct {
+	// GetImageFunc mocks the GetImage method.
+	GetImageFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, imageID string) (image.Image, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetImage holds details about calls to the GetImage method.
+		GetImage []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// UserAuthToken is the userAuthToken argument value.
+			UserAuthToken string
+			// ServiceAuthToken is the serviceAuthToken argument value.
+			ServiceAuthToken string
+			// CollectionID is the collectionID argument value.
+			CollectionID string
+			// ImageID is the imageID argument value.
+			ImageID string
+		}
+	}
+}
+
+// GetImage calls GetImageFunc.
+func (mock *ImageClientMock) GetImage(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, imageID string) (image.Image, error) {
+	if mock.GetImageFunc == nil {
+		panic("ImageClientMock.GetImageFunc: method is nil but ImageClient.GetImage was just called")
+	}
+	callInfo := struct {
+		Ctx              context.Context
+		UserAuthToken    string
+		ServiceAuthToken string
+		CollectionID     string
+		ImageID          string
+	}{
+		Ctx:              ctx,
+		UserAuthToken:    userAuthToken,
+		ServiceAuthToken: serviceAuthToken,
+		CollectionID:     collectionID,
+		ImageID:          imageID,
+	}
+	lockImageClientMockGetImage.Lock()
+	mock.calls.GetImage = append(mock.calls.GetImage, callInfo)
+	lockImageClientMockGetImage.Unlock()
+	return mock.GetImageFunc(ctx, userAuthToken, serviceAuthToken, collectionID, imageID)
+}
+
+// GetImageCalls gets all the calls that were made to GetImage.
+// Check the length with:
+//     len(mockedImageClient.GetImageCalls())
+func (mock *ImageClientMock) GetImageCalls() []struct {
+	Ctx              context.Context
+	UserAuthToken    string
+	ServiceAuthToken string
+	CollectionID     string
+	ImageID          string
+} {
+	var calls []struct {
+		Ctx              context.Context
+		UserAuthToken    string
+		ServiceAuthToken string
+		CollectionID     string
+		ImageID          string
+	}
+	lockImageClientMockGetImage.RLock()
+	calls = mock.calls.GetImage
+	lockImageClientMockGetImage.RUnlock()
 	return calls
 }
 

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func run(ctx context.Context) error {
 	}
 
 	healthcheck := health.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)
-	if err = registerCheckers(ctx, &healthcheck, clients.Renderer, clients.Zebedee, clients.Babbage); err != nil {
+	if err = registerCheckers(ctx, &healthcheck, clients.Renderer, clients.Zebedee, clients.Babbage, clients.ImageAPI); err != nil {
 		return err
 	}
 	routes.Init(ctx, r, healthcheck, clients)
@@ -124,7 +124,7 @@ func gracefulShutdown(cfg *config.Config, s *server.Server, hc health.HealthChec
 	return nil
 }
 
-func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Renderer, z *zebedee.Client, b *release_calendar.Client) (err error) {
+func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Renderer, z *zebedee.Client, b *release_calendar.Client, i *image.Client) (err error) {
 	if err = h.AddCheck("frontend renderer", r.Checker); err != nil {
 		log.Event(ctx, "failed to add frontend renderer checker", log.Error(err))
 	}
@@ -133,6 +133,9 @@ func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Re
 	}
 	if err = h.AddCheck("Babbage", b.Checker); err != nil {
 		log.Event(ctx, "failed to add babbage checker", log.Error(err))
+	}
+	if err = h.AddCheck("Image API", i.Checker); err != nil {
+		log.Event(ctx, "failed to add image api checker", log.Error(err))
 	}
 	return
 }

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
+
+	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/renderer"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -65,8 +67,8 @@ func run(ctx context.Context) error {
 		Renderer: renderer.New(cfg.RendererURL),
 		Zebedee:  zebedee.New(cfg.ZebedeeURL),
 		Babbage:  release_calendar.New(cfg.BabbageURL),
+		ImageAPI: image.NewAPIClient(cfg.ImageURL),
 	}
-
 
 	healthcheck := health.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)
 	if err = registerCheckers(ctx, &healthcheck, clients.Renderer, clients.Zebedee, clients.Babbage); err != nil {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	model "github.com/ONSdigital/dp-frontend-models/model/homepage"
@@ -82,16 +83,27 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 }
 
 // FeaturedContent takes the homepageContent as returned from the client and returns an array of featured content
-func FeaturedContent(homepageData zebedee.HomepageContent) []model.Feature {
+func FeaturedContent(homepageData zebedee.HomepageContent, imageObjects []image.Image) []model.Feature {
 	var mappedFeaturesArray []model.Feature
-	for _, fc := range homepageData.FeaturedContent {
+	for i, fc := range homepageData.FeaturedContent {
+		imageHref := findMatchingImageHref(homepageData.FeaturedContent[i].ImageID, imageObjects)
 		mappedFeaturesArray = append(mappedFeaturesArray, model.Feature{
 			Title:       fc.Title,
 			Description: fc.Description,
 			URI:         fc.URI,
+			ImageURL:    imageHref,
 		})
 	}
 	return mappedFeaturesArray
+}
+
+func findMatchingImageHref(imageID string, imageObjects []image.Image) string {
+	for i := range imageObjects {
+		if imageObjects[i].Id == imageID {
+			return imageObjects[i].Downloads["png"]["thumbnail"].Href
+		}
+	}
+	return ""
 }
 
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 
+	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	model "github.com/ONSdigital/dp-frontend-models/model/homepage"
 	. "github.com/smartystreets/goconvey/convey"
@@ -174,19 +175,19 @@ func TestUnitMapper(t *testing.T) {
 				Title:       "Featured content one",
 				Description: "Featured content one description",
 				URI:         "Featured content one URI",
-				ImageID:     "1-id",
+				ImageID:     "123",
 			},
 			{
 				Title:       "Featured content two",
 				Description: "Featured content two description",
 				URI:         "Featured content two URI",
-				ImageID:     "2-id",
+				ImageID:     "456",
 			},
 			{
 				Title:       "Featured content three",
 				Description: "Featured content three description",
 				URI:         "Featured content three URI",
-				ImageID:     "3-id",
+				ImageID:     "",
 			},
 		},
 		ServiceMessage: "",
@@ -207,19 +208,45 @@ func TestUnitMapper(t *testing.T) {
 			Title:       "Featured content one",
 			Description: "Featured content one description",
 			URI:         "Featured content one URI",
-			ImageURL:    "/1-id.svg",
+			ImageURL:    "path/to/123.png",
 		},
 		{
 			Title:       "Featured content two",
 			Description: "Featured content two description",
 			URI:         "Featured content two URI",
-			ImageURL:    "/2-id.svg",
+			ImageURL:    "path/to/456.png",
 		},
 		{
 			Title:       "Featured content three",
 			Description: "Featured content three description",
 			URI:         "Featured content three URI",
-			ImageURL:    "/3-id.svg",
+			ImageURL:    "",
+		},
+	}
+	var mockedImageData = []image.Image{
+		{
+			Id:           "123",
+			CollectionId: "",
+			Filename:     "123.png",
+			Downloads: map[string]map[string]image.ImageDownload{
+				"png": {
+					"thumbnail": {
+						Href: "path/to/123.png",
+					},
+				},
+			},
+		},
+		{
+			Id:           "456",
+			CollectionId: "",
+			Filename:     "456.png",
+			Downloads: map[string]map[string]image.ImageDownload{
+				"png": {
+					"thumbnail": {
+						Href: "path/to/456.png",
+					},
+				},
+			},
 		},
 	}
 
@@ -249,18 +276,23 @@ func TestUnitMapper(t *testing.T) {
 	Convey("test FeaturedContent", t, func() {
 		Convey("FeaturedContent handles when no homepage data is passed in", func() {
 			mockedTestData := zebedee.HomepageContent{}
-			featuredContent := FeaturedContent(mockedTestData)
+			mockedImageTestData := []image.Image{}
+			featuredContent := FeaturedContent(mockedTestData, mockedImageTestData)
 			So(featuredContent, ShouldBeNil)
 		})
 
 		Convey("FeaturedContent maps mock data to page model correctly", func() {
 			mockedTestData := mockedHomepageData
-			featuredContent := FeaturedContent(mockedTestData)
+			mockedImageTestData := mockedImageData
+			featuredContent := FeaturedContent(mockedTestData, mockedImageTestData)
 			So(len(featuredContent), ShouldEqual, 3)
 			for i := 0; i < len(featuredContent); i++ {
 				So(featuredContent[i].Title, ShouldEqual, mockedTestData.FeaturedContent[i].Title)
 				So(featuredContent[i].Description, ShouldEqual, mockedTestData.FeaturedContent[i].Description)
 				So(featuredContent[i].URI, ShouldEqual, mockedTestData.FeaturedContent[i].URI)
+				if featuredContent[i].ImageURL != "" {
+					So(featuredContent[i].ImageURL, ShouldEqual, mockedImageData[i].Downloads["png"]["thumbnail"].Href)
+				}
 			}
 		})
 	})

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -2,8 +2,10 @@ package routes
 
 import (
 	"context"
+
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 
+	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/renderer"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-homepage-controller/homepage"
@@ -13,11 +15,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type Clients struct{
+type Clients struct {
 	Renderer *renderer.Renderer
-	Zebedee *zebedee.Client
-	Babbage *release_calendar.Client
+	Zebedee  *zebedee.Client
+	Babbage  *release_calendar.Client
+	ImageAPI *image.Client
 }
+
 // Init initialises routes for the service
 func Init(ctx context.Context, r *mux.Router, hc health.HealthCheck, c Clients) {
 	log.Event(ctx, "adding routes")

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -26,5 +26,5 @@ type Clients struct {
 func Init(ctx context.Context, r *mux.Router, hc health.HealthCheck, c Clients) {
 	log.Event(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
-	r.StrictSlash(true).Path("/").Methods("GET").HandlerFunc(homepage.Handler(c.Renderer, c.Zebedee, c.Babbage))
+	r.StrictSlash(true).Path("/").Methods("GET").HandlerFunc(homepage.Handler(c.Renderer, c.Zebedee, c.Babbage, c.ImageAPI))
 }


### PR DESCRIPTION
### What

This PR adds the functionality for images to be loaded in from the image API, and for the relevant Hrefs to be mapped to the featured content struct, ready for use by the renderer.

- Added Image API URL to config
- Added ImageAPI healthcheck
- Added call to Image API to fetch relevant image data based on ID provided by Zebedee
- Map image Href to featured content struct
- Updated mocks to account for new ImageClient interface
- Tests

### How to review

- Check code changes make sense
- Ensure tests pass and that the expected page model gets created

### Who can review

Anyone but me
