### PR TITLE
add test case to cover when image href is empty in mapper

### DIFF
--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -294,6 +294,7 @@ func TestUnitMapper(t *testing.T) {
 					So(featuredContent[i].ImageURL, ShouldEqual, mockedImageData[i].Downloads["png"]["thumbnail"].Href)
 				}
 			}
+			So(featuredContent[2].ImageURL, ShouldEqual, "")
 		})
 	})
 


### PR DESCRIPTION
### What

Added a test case to the mapper to cover when an image href is empty. When this is the case, the featured content element should have `ImageURL` set to an empty string. 

### How to review

- Check additional test case change and that tests still pass

### Who can review

Anyone but me