### PR TITLE
update employment/unemployment period from Month to Year

### DIFF
--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -139,14 +139,14 @@ func init() {
 	// Employment
 	mainFigureMap["LF24"] = MainFigure{
 		uri:        "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/lf24/lms",
-		datePeriod: PeriodMonth,
+		datePeriod: PeriodYear,
 		data:       zebedee.TimeseriesMainFigure{},
 	}
 
 	// Unemployment
 	mainFigureMap["MGSX"] = MainFigure{
 		uri:        "/employmentandlabourmarket/peoplenotinwork/unemployment/timeseries/mgsx/lms",
-		datePeriod: PeriodMonth,
+		datePeriod: PeriodYear,
 		data:       zebedee.TimeseriesMainFigure{},
 	}
 


### PR DESCRIPTION
### What

This PR updates the `Employment` and `Unemployment` to take the Yearly figures instead of the Monthly. Owing to the change, the heights no longer quite aligned on desktop viewport sizes, so an additional PR for the renderer accompanies this piece of work.

**Without setting a height to the text**
![image](https://user-images.githubusercontent.com/23668262/86333354-b0026880-bc43-11ea-8e8b-ea048d3d1001.png)

**With setting explicit height to the text**
![image](https://user-images.githubusercontent.com/23668262/86333244-8e08e600-bc43-11ea-8aa4-5ec295caa3f0.png)

### How to review

- Ensure that annual figures are used for the employment/unemployment data instead of monthly
- Ensure that the correct timeseries and data is being pulled in
- Check the Renderer PR and ensure that the changes make sense

### Who can review

Anyone but me
