### PR TITLE
Fix difference indicator accuracy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/ONSdigital/dp-rchttp v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
-	github.com/dustin/go-humanize v1.0.0
 	github.com/gorilla/mux v1.7.4
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/matryer/moq v0.0.0-20191105074349-1206bf1e2aad // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/shopspring/decimal v1.2.0
 	github.com/smartystreets/goconvey v1.6.4
 	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
 	golang.org/x/sys v0.0.0-20200427175716-29b57079015a // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,10 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/robfig/humanize v0.0.0-20130801072920-4123e5c9f2f9 h1:ox2YYDFeBLtX+ppK/wsDCdIjxiyrb9N+nZUzutCwSkc=
+github.com/robfig/humanize v0.0.0-20130801072920-4123e5c9f2f9/go.mod h1:22cALbnMi4X46KeLCD6AD0kHX9bX4MBXvKEEOvrNiKc=
+github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
+github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -114,6 +118,9 @@ golang.org/x/sys v0.0.0-20200427175716-29b57079015a h1:08u6b1caTT9MQY4wSbmsd4Ulm
 golang.org/x/sys v0.0.0-20200427175716-29b57079015a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,15 +3,15 @@ package mapper
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
-	"strconv"
 
 	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
 	model "github.com/ONSdigital/dp-frontend-models/model/homepage"
 	"github.com/ONSdigital/log.go/log"
-	"github.com/dustin/go-humanize"
+	"github.com/shopspring/decimal"
 )
 
 // Homepage maps data to our homepage frontend model
@@ -37,20 +37,18 @@ func MainFigure(ctx context.Context, id, datePeriod string, figure zebedee.Times
 	previousDataIndex := len(mfData) - 2
 	latestData := mfData[latestDataIndex]
 	previousData := mfData[previousDataIndex]
-	latestFigure, err := strconv.ParseFloat(latestData.Value, 64)
+	latestFigure, err := decimal.NewFromString(latestData.Value)
 	if err != nil {
-		log.Event(ctx, "error getting trend description: error parsing float", log.Error(err))
+		log.Event(ctx, "error getting trend description: error converting string to decimal type", log.Error(err))
 		return &mf
 	}
-	previousFigure, err := strconv.ParseFloat(previousData.Value, 64)
+	previousFigure, err := decimal.NewFromString(previousData.Value)
 	if err != nil {
-		log.Event(ctx, "error getting trend description: error parsing float", log.Error(err))
+		log.Event(ctx, "error getting trend description: error converting string to decimal type", log.Error(err))
 		return &mf
 	}
 
-	latestFigureFormatted := humanize.CommafWithDigits(latestFigure, 2)
-
-	mf.Figure = latestFigureFormatted
+	mf.Figure = formatCommas(latestFigure)
 	mf.Date = latestData.Label
 	mf.Unit = figure.Description.Unit
 	mf.Trend = getTrend(latestFigure, previousFigure)
@@ -150,23 +148,23 @@ func getDataByPeriod(datePeriod string, data zebedee.TimeseriesMainFigure) []zeb
 }
 
 // getTrend returns trend boolean value based on latest and previous figures
-func getTrend(latest, previous float64) model.Trend {
-	if latest > previous {
+func getTrend(latest, previous decimal.Decimal) model.Trend {
+	if latest.GreaterThan(previous) {
 		return model.Trend{IsUp: true}
 	}
 
-	if latest < previous {
+	if latest.LessThan(previous) {
 		return model.Trend{IsDown: true}
 	}
 
-	if latest == previous {
+	if latest.Equal(previous) {
 		return model.Trend{IsFlat: true}
 	}
 	return model.Trend{}
 }
 
 // getTrendDifference returns string value of the difference between latest and previous
-func getTrendDifference(latest, previous float64, unit string) string {
+func getTrendDifference(latest, previous decimal.Decimal, unit string) string {
 	var trendUnit string
 	switch unit {
 	case "%":
@@ -174,7 +172,19 @@ func getTrendDifference(latest, previous float64, unit string) string {
 	default:
 		trendUnit = unit
 	}
-	diff := float64(latest - previous)
-	formattedDiff := humanize.CommafWithDigits(diff, 2)
-	return fmt.Sprintf("%v%v", formattedDiff, trendUnit)
+	diff := latest.Sub(previous)
+	diffStr := diff.StringFixed(1)
+	//formattedDiff := humanize.CommafWithDigits(diff, 2)
+	return fmt.Sprintf("%v%v", diffStr, trendUnit)
+}
+
+// formats large numbers to contain comma separators e.g. 1000000 => 1,000,000
+func formatCommas(num decimal.Decimal) string {
+	str := fmt.Sprintf("%v", num.StringFixed(1))
+	re := regexp.MustCompile("(\\d+)(\\d{3})")
+	for n := ""; n != str; {
+		n = str
+		str = re.ReplaceAllString(str, "$1,$2")
+	}
+	return str
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dp-frontend-homepage-controller/clients/release_calendar"
+	"github.com/shopspring/decimal"
 
 	"github.com/ONSdigital/dp-api-clients-go/image"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
@@ -250,6 +251,15 @@ func TestUnitMapper(t *testing.T) {
 		},
 	}
 
+	testFigure1, _ := decimal.NewFromString("12.345")
+	testFigure2, _ := decimal.NewFromString("8.90")
+	testFigure3, _ := decimal.NewFromString("100.2")
+	testFigure4, _ := decimal.NewFromString("101.423")
+	testFigure5, _ := decimal.NewFromString("88.8888")
+	testFigure6, _ := decimal.NewFromString("64890980.683628")
+	testFigure7, _ := decimal.NewFromString("1000.2")
+	testFigure8, _ := decimal.NewFromString("88789.12")
+
 	Convey("test homepage mapping works", t, func() {
 		page := Homepage("en", mockedMainFigures, &mockedReleaseData, &mockedFeaturedContent)
 
@@ -264,7 +274,7 @@ func TestUnitMapper(t *testing.T) {
 		mockedTestData := mockedZebedeeData[0]
 		mainFigures := MainFigure(ctx, "cdid", "month", mockedTestData)
 		So(mainFigures.Date, ShouldEqual, "Feb 2020")
-		So(mainFigures.Figure, ShouldEqual, "679.56")
+		So(mainFigures.Figure, ShouldEqual, "679.6")
 		So(mainFigures.Trend.IsDown, ShouldEqual, false)
 		So(mainFigures.Trend.IsUp, ShouldEqual, true)
 		So(mainFigures.Trend.IsFlat, ShouldEqual, false)
@@ -308,23 +318,30 @@ func TestUnitMapper(t *testing.T) {
 	})
 
 	Convey("test getTrend returns current struct of bools", t, func() {
-		trendPositive := getTrend(5.8, 4.5672)
-		trendNegative := getTrend(9.99, 10.21)
-		trendFlat := getTrend(8.88, 8.88)
+		trendPositive := getTrend(testFigure1, testFigure2)
+		trendNegative := getTrend(testFigure3, testFigure4)
+		trendFlat := getTrend(testFigure5, testFigure5)
 		So(trendPositive, ShouldResemble, model.Trend{IsUp: true, IsDown: false, IsFlat: false})
 		So(trendNegative, ShouldResemble, model.Trend{IsUp: false, IsDown: true, IsFlat: false})
 		So(trendFlat, ShouldResemble, model.Trend{IsUp: false, IsDown: false, IsFlat: true})
 	})
 
 	Convey("test getTrendDiffference returns the current string", t, func() {
-		trendDescriptionPositive := getTrendDifference(10.55, 8.568, "million")
-		trendDescriptionNegative := getTrendDifference(10.5, 18.7, "%")
-		So(trendDescriptionPositive, ShouldEqual, "1.98million")
-		So(trendDescriptionNegative, ShouldEqual, "-8.2pp")
+		trendDescriptionPositive := getTrendDifference(testFigure1, testFigure2, "million")
+		trendDescriptionNegative := getTrendDifference(testFigure3, testFigure4, "%")
+		So(trendDescriptionPositive, ShouldEqual, "3.4million")
+		So(trendDescriptionNegative, ShouldEqual, "-1.2pp")
 	})
 
 	Convey("test release calendar maps data correctly", t, func() {
 		So(ReleaseCalendar(mockedBabbageRelease), ShouldResemble, &mockedReleaseData)
+	})
+
+	Convey("test formatCommas returns correctly formatted numbers as string", t, func() {
+		So(formatCommas(testFigure1), ShouldEqual, "12.3")
+		So(formatCommas(testFigure6), ShouldEqual, "64,890,980.7")
+		So(formatCommas(testFigure7), ShouldEqual, "1,000.2")
+		So(formatCommas(testFigure8), ShouldEqual, "88,789.1")
 	})
 
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -256,9 +256,6 @@ func TestUnitMapper(t *testing.T) {
 	testFigure3, _ := decimal.NewFromString("100.2")
 	testFigure4, _ := decimal.NewFromString("101.423")
 	testFigure5, _ := decimal.NewFromString("88.8888")
-	testFigure6, _ := decimal.NewFromString("64890980.683628")
-	testFigure7, _ := decimal.NewFromString("1000.2")
-	testFigure8, _ := decimal.NewFromString("88789.12")
 
 	Convey("test homepage mapping works", t, func() {
 		page := Homepage("en", mockedMainFigures, &mockedReleaseData, &mockedFeaturedContent)
@@ -338,10 +335,10 @@ func TestUnitMapper(t *testing.T) {
 	})
 
 	Convey("test formatCommas returns correctly formatted numbers as string", t, func() {
-		So(formatCommas(testFigure1), ShouldEqual, "12.3")
-		So(formatCommas(testFigure6), ShouldEqual, "64,890,980.7")
-		So(formatCommas(testFigure7), ShouldEqual, "1,000.2")
-		So(formatCommas(testFigure8), ShouldEqual, "88,789.1")
+		So(formatCommas("12.3"), ShouldEqual, "12.3")
+		So(formatCommas("64890980.7"), ShouldEqual, "64,890,980.7")
+		So(formatCommas("1000.2"), ShouldEqual, "1,000.2")
+		So(formatCommas("88789.1"), ShouldEqual, "88,789.1")
 	})
 
 }


### PR DESCRIPTION
### What

- Use `decimal.Decimal` type instead of floats
- Add `formatCommas` func for adding commas to large numbers

### Who can review

Anyone
