### PR TITLE
Revert "update employment/unemployment period from Month to Year"

### DIFF
--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -139,14 +139,14 @@ func init() {
 	// Employment
 	mainFigureMap["LF24"] = MainFigure{
 		uri:        "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/lf24/lms",
-		datePeriod: PeriodYear,
+		datePeriod: PeriodMonth,
 		data:       zebedee.TimeseriesMainFigure{},
 	}
 
 	// Unemployment
 	mainFigureMap["MGSX"] = MainFigure{
 		uri:        "/employmentandlabourmarket/peoplenotinwork/unemployment/timeseries/mgsx/lms",
-		datePeriod: PeriodYear,
+		datePeriod: PeriodMonth,
 		data:       zebedee.TimeseriesMainFigure{},
 	}
 


### PR DESCRIPTION
### What

This reverts commit bcb5a2bc62ae46e8cab4a56aa8b786480e32fad6. 

This is owing to change in requirements for the piece of work outlined in [the Employment difference indicator](https://trello.com/c/7PZUHha2/261-update-employment-difference-indicator-range-to-on-previous-year-1) ticket

### How to review

Check that the `datePeriod` value for Employment and Unemployment is `PeriodMonth` instead of `PeriodYear`

### Who can review

Anyone but me
