### PR TITLE
update dp-api-clients-go and update download reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/ONSdigital/dp-frontend-homepage-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.13.1
+	github.com/ONSdigital/dp-api-clients-go v1.17.0
 	github.com/ONSdigital/dp-cookies v0.1.0 // indirect
-	github.com/ONSdigital/dp-frontend-models v1.5.7
+	github.com/ONSdigital/dp-frontend-models v1.6.0
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-rchttp v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/ONSdigital/dp-api-clients-go v1.13.0 h1:5vA5VWlMcezyOvFn2Zbi6lq0J2waj
 github.com/ONSdigital/dp-api-clients-go v1.13.0/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
 github.com/ONSdigital/dp-api-clients-go v1.13.1 h1:l44vosPVDwe6ht6BcBikRUBAkDFB5aqmHfFjZtKtn1U=
 github.com/ONSdigital/dp-api-clients-go v1.13.1/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
+github.com/ONSdigital/dp-api-clients-go v1.17.0 h1:5+10J0pCtNMJKvDhDWucQwRhenz9iNisN2s5kaKP4rE=
+github.com/ONSdigital/dp-api-clients-go v1.17.0/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
@@ -28,6 +30,8 @@ github.com/ONSdigital/dp-frontend-models v1.5.6 h1:PczSyRVst45I8YFjgYVwUaq6UBdUm
 github.com/ONSdigital/dp-frontend-models v1.5.6/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.5.7 h1:J7eNiZF33BWpR0/uWtJlXwsjEYK4vF8X3+9X0l6IECo=
 github.com/ONSdigital/dp-frontend-models v1.5.7/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.6.0 h1:hWdFrm6bKlK0AD3HeY2CG2Idjzbfv74vDtKxlyH1hhk=
+github.com/ONSdigital/dp-frontend-models v1.6.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=

--- a/homepage/homepage_test.go
+++ b/homepage/homepage_test.go
@@ -170,11 +170,9 @@ func TestUnitMapper(t *testing.T) {
 			Id:           "123",
 			CollectionId: "",
 			Filename:     "123.png",
-			Downloads: map[string]map[string]image.ImageDownload{
+			Downloads: map[string]image.ImageDownload{
 				"png": {
-					"thumbnail": {
-						Href: "path/to/123.png",
-					},
+					Href: "path/to/123.png",
 				},
 			},
 		},
@@ -182,11 +180,9 @@ func TestUnitMapper(t *testing.T) {
 			Id:           "456",
 			CollectionId: "",
 			Filename:     "456.png",
-			Downloads: map[string]map[string]image.ImageDownload{
+			Downloads: map[string]image.ImageDownload{
 				"png": {
-					"thumbnail": {
-						Href: "path/to/456.png",
-					},
+					Href: "path/to/456.png",
 				},
 			},
 		},

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -100,7 +100,7 @@ func FeaturedContent(homepageData zebedee.HomepageContent, imageObjects []image.
 func findMatchingImageHref(imageID string, imageObjects []image.Image) string {
 	for i := range imageObjects {
 		if imageObjects[i].Id == imageID {
-			return imageObjects[i].Downloads["png"]["thumbnail"].Href
+			return imageObjects[i].Downloads["png"].Href
 		}
 	}
 	return ""

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -228,11 +228,9 @@ func TestUnitMapper(t *testing.T) {
 			Id:           "123",
 			CollectionId: "",
 			Filename:     "123.png",
-			Downloads: map[string]map[string]image.ImageDownload{
+			Downloads: map[string]image.ImageDownload{
 				"png": {
-					"thumbnail": {
-						Href: "path/to/123.png",
-					},
+					Href: "path/to/123.png",
 				},
 			},
 		},
@@ -240,11 +238,9 @@ func TestUnitMapper(t *testing.T) {
 			Id:           "456",
 			CollectionId: "",
 			Filename:     "456.png",
-			Downloads: map[string]map[string]image.ImageDownload{
+			Downloads: map[string]image.ImageDownload{
 				"png": {
-					"thumbnail": {
-						Href: "path/to/456.png",
-					},
+					Href: "path/to/456.png",
 				},
 			},
 		},
@@ -291,7 +287,7 @@ func TestUnitMapper(t *testing.T) {
 				So(featuredContent[i].Description, ShouldEqual, mockedTestData.FeaturedContent[i].Description)
 				So(featuredContent[i].URI, ShouldEqual, mockedTestData.FeaturedContent[i].URI)
 				if featuredContent[i].ImageURL != "" {
-					So(featuredContent[i].ImageURL, ShouldEqual, mockedImageData[i].Downloads["png"]["thumbnail"].Href)
+					So(featuredContent[i].ImageURL, ShouldEqual, mockedImageData[i].Downloads["png"].Href)
 				}
 			}
 			So(featuredContent[2].ImageURL, ShouldEqual, "")


### PR DESCRIPTION
### What

This PR updates `dp-api-clients-go` and `dp-frontend-models` to the most recent versions

As a result of updating the clients library, the Image Downloads struct has also been tweaked to match the updated map structure. The image download map now only has one level as opposed to the two previously

### How to review

Check tests pass and that the changes align with requirements 

### Who can review

Anyone but me
