### PR TITLE
LMS offset changes and fix falling over when no data returned from Zebedee

### DIFF
--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -18,20 +18,15 @@ import (
 )
 
 const (
-	// PeriodYear is the string value for year time period
-	PeriodYear = "year"
-	// PeriodQuarter is the string value for quarter time period
-	PeriodQuarter = "quarter"
-	// PeriodMonth is the string value for month time period
-	PeriodMonth = "month"
 	// HomepagePath is the string value which contains the URI to get the homepage's data.json
 	HomepagePath = "/"
 )
 
 type MainFigure struct {
-	uri        string
-	datePeriod string
-	data       zebedee.TimeseriesMainFigure
+	uri                string
+	datePeriod         string
+	data               zebedee.TimeseriesMainFigure
+	differenceInterval string
 }
 
 var mainFigureMap map[string]MainFigure
@@ -75,7 +70,7 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 				responses <- mappedErrorFigure
 				return
 			}
-			mappedMainFigure := mapper.MainFigure(ctx, id, figure.datePeriod, zebResp)
+			mappedMainFigure := mapper.MainFigure(ctx, id, figure.datePeriod, figure.differenceInterval, zebResp)
 			responses <- mappedMainFigure
 			return
 		}(ctx, zcli, id, figure)
@@ -138,37 +133,42 @@ func init() {
 
 	// Employment
 	mainFigureMap["LF24"] = MainFigure{
-		uri:        "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/lf24/lms",
-		datePeriod: PeriodMonth,
-		data:       zebedee.TimeseriesMainFigure{},
+		uri:                "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/timeseries/lf24/lms",
+		datePeriod:         mapper.PeriodMonth,
+		data:               zebedee.TimeseriesMainFigure{},
+		differenceInterval: mapper.PeriodYear,
 	}
 
 	// Unemployment
 	mainFigureMap["MGSX"] = MainFigure{
-		uri:        "/employmentandlabourmarket/peoplenotinwork/unemployment/timeseries/mgsx/lms",
-		datePeriod: PeriodMonth,
-		data:       zebedee.TimeseriesMainFigure{},
+		uri:                "/employmentandlabourmarket/peoplenotinwork/unemployment/timeseries/mgsx/lms",
+		datePeriod:         mapper.PeriodMonth,
+		data:               zebedee.TimeseriesMainFigure{},
+		differenceInterval: mapper.PeriodYear,
 	}
 
 	// Inflation (CPIH)
 	mainFigureMap["L55O"] = MainFigure{
-		uri:        "/economy/inflationandpriceindices/timeseries/l55o/mm23",
-		datePeriod: PeriodMonth,
-		data:       zebedee.TimeseriesMainFigure{},
+		uri:                "/economy/inflationandpriceindices/timeseries/l55o/mm23",
+		datePeriod:         mapper.PeriodMonth,
+		data:               zebedee.TimeseriesMainFigure{},
+		differenceInterval: mapper.PeriodMonth,
 	}
 
 	// GDP
 	mainFigureMap["IHYQ"] = MainFigure{
-		uri:        "/economy/grossdomesticproductgdp/timeseries/ihyq/qna",
-		datePeriod: PeriodQuarter,
-		data:       zebedee.TimeseriesMainFigure{},
+		uri:                "/economy/grossdomesticproductgdp/timeseries/ihyq/qna",
+		datePeriod:         mapper.PeriodQuarter,
+		data:               zebedee.TimeseriesMainFigure{},
+		differenceInterval: mapper.PeriodQuarter,
 	}
 
 	// Population
 	mainFigureMap["UKPOP"] = MainFigure{
-		uri:        "/peoplepopulationandcommunity/populationandmigration/populationestimates/timeseries/ukpop/pop",
-		datePeriod: PeriodYear,
-		data:       zebedee.TimeseriesMainFigure{},
+		uri:                "/peoplepopulationandcommunity/populationandmigration/populationestimates/timeseries/ukpop/pop",
+		datePeriod:         mapper.PeriodYear,
+		data:               zebedee.TimeseriesMainFigure{},
+		differenceInterval: mapper.PeriodYear,
 	}
 
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -48,7 +48,7 @@ func MainFigure(ctx context.Context, id, datePeriod, differenceInterval string, 
 
 	mfData := getDataByPeriod(datePeriod, figure)
 	previousDataOffset := getDifferenceOffset(datePeriod, differenceInterval) + 1
-	if len(mfData) > previousDataOffset {
+	if len(mfData) < previousDataOffset {
 		log.Event(ctx, "error: too few observations in timeseries array", log.Error(errors.New("too few observations in timeseries array")))
 		return &mf
 	}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -12,6 +13,15 @@ import (
 	model "github.com/ONSdigital/dp-frontend-models/model/homepage"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/shopspring/decimal"
+)
+
+const (
+	// PeriodYear is the string value for year time period
+	PeriodYear = "year"
+	// PeriodQuarter is the string value for quarter time period
+	PeriodQuarter = "quarter"
+	// PeriodMonth is the string value for month time period
+	PeriodMonth = "month"
 )
 
 // decimalPointDisplayThreshold is a number where we no longer want to
@@ -31,14 +41,19 @@ func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, relea
 }
 
 // MainFigure maps a single main figure object
-func MainFigure(ctx context.Context, id, datePeriod string, figure zebedee.TimeseriesMainFigure) *model.MainFigure {
+func MainFigure(ctx context.Context, id, datePeriod, differenceInterval string, figure zebedee.TimeseriesMainFigure) *model.MainFigure {
 	var mf model.MainFigure
 
 	mf.ID = id
 
 	mfData := getDataByPeriod(datePeriod, figure)
+	previousDataOffset := getDifferenceOffset(datePeriod, differenceInterval) + 1
+	if len(mfData) > previousDataOffset {
+		log.Event(ctx, "error: too few observations in timeseries array", log.Error(errors.New("too few observations in timeseries array")))
+		return &mf
+	}
 	latestDataIndex := len(mfData) - 1
-	previousDataIndex := len(mfData) - 2
+	previousDataIndex := len(mfData) - previousDataOffset
 	latestData := mfData[latestDataIndex]
 	previousData := mfData[previousDataIndex]
 	latestFigure, err := decimal.NewFromString(latestData.Value)
@@ -64,7 +79,7 @@ func MainFigure(ctx context.Context, id, datePeriod string, figure zebedee.Times
 	mf.Unit = figure.Description.Unit
 	mf.Trend = getTrend(latestFigure, previousFigure)
 	mf.Trend.Difference = getTrendDifference(latestFigure, previousFigure, figure.Description.Unit)
-	mf.Trend.Period = datePeriod
+	mf.Trend.Period = differenceInterval
 	if len(figure.RelatedDocuments) > 0 {
 		mf.FigureURIs.Analysis = figure.RelatedDocuments[0].URI
 	}
@@ -146,11 +161,11 @@ func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {
 func getDataByPeriod(datePeriod string, data zebedee.TimeseriesMainFigure) []zebedee.TimeseriesDataPoint {
 	var mf []zebedee.TimeseriesDataPoint
 	switch datePeriod {
-	case "year":
+	case PeriodYear:
 		mf = data.Years
-	case "quarter":
+	case PeriodQuarter:
 		mf = data.Quarters
-	case "month":
+	case PeriodMonth:
 		mf = data.Months
 	default:
 		mf = []zebedee.TimeseriesDataPoint{}
@@ -197,4 +212,27 @@ func formatCommas(str string) string {
 		str = re.ReplaceAllString(str, "$1,$2")
 	}
 	return str
+}
+
+// getDifferenceOffset works out a numeric value that represents the
+// offset of values to compare from data in a timeseries
+func getDifferenceOffset(period, interval string) int {
+	if period == interval {
+		return 1
+	}
+
+	if period == PeriodQuarter && interval == PeriodYear {
+		return 4
+	}
+
+	if period == PeriodMonth {
+		if interval == PeriodYear {
+			return 12
+		}
+		if interval == PeriodQuarter {
+			return 3
+		}
+	}
+	// only gets here if incomparable options are chosen in code
+	panic("unable to get difference offset from choosen period and interval values")
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -265,7 +265,7 @@ func TestUnitMapper(t *testing.T) {
 
 	Convey("test main figures mapping works", t, func() {
 		mockedTestData := mockedZebedeeData[0]
-		mainFigures := MainFigure(ctx, "cdid", "month", mockedTestData)
+		mainFigures := MainFigure(ctx, "cdid", PeriodMonth, PeriodMonth, mockedTestData)
 		So(mainFigures.Date, ShouldEqual, "Feb 2020")
 		So(mainFigures.Figure, ShouldEqual, "679.6")
 		So(mainFigures.Trend.IsDown, ShouldEqual, false)
@@ -337,4 +337,11 @@ func TestUnitMapper(t *testing.T) {
 		So(formatCommas("88789.1"), ShouldEqual, "88,789.1")
 	})
 
+	Convey("test getDifferenceOffset returns correct offset value", t, func() {
+		So(getDifferenceOffset(PeriodMonth, PeriodMonth), ShouldEqual, 1)
+		So(getDifferenceOffset(PeriodYear, PeriodYear), ShouldEqual, 1)
+		So(getDifferenceOffset(PeriodQuarter, PeriodYear), ShouldEqual, 4)
+		So(getDifferenceOffset(PeriodMonth, PeriodYear), ShouldEqual, 12)
+		So(getDifferenceOffset(PeriodMonth, PeriodQuarter), ShouldEqual, 3)
+	})
 }


### PR DESCRIPTION
### What

- Add an offset interval for certain datasets where we don't compare to the previous data point. E.g. we use monthly data for LMS but want to compare it the the same time last year, rather than the month before.
- Check the length of data from Zebedee is longer enough that our code wont break. If it isn't return/map an empty an empty struct

### How to review

- Run the changes and check that employment and unemployment are comparing to the previous year
- Switch to `feature/main-figures-error-state` in the render. Simulate an empty response from Zebedee then homepage-controller should log that there in insufficient data from Zebedee, and the render should render the main figure as an error

### Who can review

Anyone
