### PR TITLE
feature/graceful-degradation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,11 @@ go 1.13
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.28.0
-	github.com/ONSdigital/dp-frontend-models v1.6.0
+	github.com/ONSdigital/dp-frontend-models v1.9.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.9
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/gorilla/mux v1.8.0
-	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,11 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0 h1:ExIUlHC6uBdBlFwt/gAI0ApSzpyig
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-frontend-models v1.6.0 h1:hWdFrm6bKlK0AD3HeY2CG2Idjzbfv74vDtKxlyH1hhk=
 github.com/ONSdigital/dp-frontend-models v1.6.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.9.0 h1:Llgiapaec6VadA+bPdiMSEWykdVDTvDkbbC50ja68/4=
+github.com/ONSdigital/dp-frontend-models v1.9.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
+github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=

--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -86,18 +86,21 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	if err != nil {
 		log.Event(ctx, "error getting homepage data from client", log.ERROR, log.Error(err), log.Data{"content-path": HomepagePath})
 	}
-	imageObjects := map[string]image.ImageDownload{}
-	for _, fc := range homepageContent.FeaturedContent {
-		if fc.ImageID != "" {
-			image, err := icli.GetDownloadVariant(ctx, userAccessToken, "", "", fc.ImageID, ImageVariant)
-			if err != nil {
-				log.Event(ctx, "error getting image download variant", log.ERROR, log.Error(err), log.Data{"featured-content-entry": fc.Title})
-			}
-			imageObjects[fc.ImageID] = image
-		}
-	}
 
-	mappedFeaturedContent := mapper.FeaturedContent(homepageContent, imageObjects)
+	var mappedFeaturedContent []model.Feature
+	if len(homepageContent.FeaturedContent) > 0 {
+		imageObjects := map[string]image.ImageDownload{}
+		for _, fc := range homepageContent.FeaturedContent {
+			if fc.ImageID != "" {
+				image, err := icli.GetDownloadVariant(ctx, userAccessToken, "", "", fc.ImageID, ImageVariant)
+				if err != nil {
+					log.Event(ctx, "error getting image download variant", log.ERROR, log.Error(err), log.Data{"featured-content-entry": fc.Title})
+				}
+				imageObjects[fc.ImageID] = image
+			}
+		}
+		mappedFeaturedContent = mapper.FeaturedContent(homepageContent, imageObjects)
+	}
 
 	m := mapper.Homepage(lang, mappedMainFigures, releaseCalModelData, &mappedFeaturedContent, homepageContent.ServiceMessage)
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -232,10 +232,7 @@ func getDifferenceOffset(period, interval string) int {
 }
 
 func hasFeaturedContent(featuredContent *[]model.Feature) bool {
-	if len(*featuredContent) > 0 {
-		return true
-	}
-	return false
+	return (len(*featuredContent) > 0)
 }
 
 func hasMainFigures(mainFigures map[string]*model.MainFigure) bool {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -33,6 +33,8 @@ func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, relea
 	var page model.Page
 	page.Type = "homepage"
 	page.Metadata.Title = "Home"
+	page.Data.HasFeaturedContent = hasFeaturedContent(featuredContent)
+	page.Data.HasMainFigures = hasMainFigures(mainFigures)
 	page.HasJSONLD = true
 	page.ServiceMessage = serviceMessage
 	page.Language = localeCode
@@ -227,4 +229,20 @@ func getDifferenceOffset(period, interval string) int {
 	}
 	// only gets here if incomparable options are chosen in code
 	panic("unable to get difference offset from choosen period and interval values")
+}
+
+func hasFeaturedContent(featuredContent *[]model.Feature) bool {
+	if len(*featuredContent) > 0 {
+		return true
+	}
+	return false
+}
+
+func hasMainFigures(mainFigures map[string]*model.MainFigure) bool {
+	for _, value := range mainFigures {
+		if value.Figure != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -254,6 +254,8 @@ func TestUnitMapper(t *testing.T) {
 		So(page.Data.MainFigures["test_id"].Figure, ShouldEqual, mockedMainFigure.Figure)
 		So(page.Data.MainFigures["test_id"].TrendDescription, ShouldEqual, mockedMainFigure.TrendDescription)
 		So(page.Data.MainFigures["test_id"].Trend, ShouldResemble, mockedMainFigure.Trend)
+		So(page.Data.HasFeaturedContent, ShouldEqual, true)
+		So(page.Data.HasMainFigures, ShouldEqual, true)
 		So(len(page.Data.Featured), ShouldEqual, 3)
 	})
 
@@ -337,5 +339,14 @@ func TestUnitMapper(t *testing.T) {
 		So(getDifferenceOffset(PeriodQuarter, PeriodYear), ShouldEqual, 4)
 		So(getDifferenceOffset(PeriodMonth, PeriodYear), ShouldEqual, 12)
 		So(getDifferenceOffset(PeriodMonth, PeriodQuarter), ShouldEqual, 3)
+	})
+
+	Convey("test graceful degradation state is properly mapped", t, func() {
+		var mockedNoFeaturedContent []model.Feature
+		var mockedNoMainFigures = make(map[string]*model.MainFigure)
+
+		gracefulDegradationPage := Homepage("en", mockedNoMainFigures, &mockedReleaseData, &mockedNoFeaturedContent, serviceMessage)
+		So(gracefulDegradationPage.Data.HasFeaturedContent, ShouldEqual, false)
+		So(gracefulDegradationPage.Data.HasMainFigures, ShouldEqual, false)
 	})
 }


### PR DESCRIPTION
### What

- Implement `HasMainFigures` and `HasFeaturedContent` properties to render graceful degradation states.
- Code optimisation: logic to fetch images for featured content is now wrapped in an if statement which checks to see if there is any featured content in the first place.

### How to review

- Check that the changes make sense
- You can review in conjunction with the [frontend renderer PR](https://github.com/ONSdigital/dp-frontend-renderer/pull/522) (follow graceful degradation steps below)

**Graceful degradation states for checking locally**
1. Comment out a main figure URI in `homepage.go` in dp-frontend-homepage-controller: that corresponding tile in the homepage should show an failed to load state
2. Comment out all main figure URIs in `homepage.go` in dp-frontend-homepage-controller: all the tiles are replaced by a single tile, aligned to the latest releases tile, that shares the same fail state message
3. Contrive a way to not have any latest releases in the last 7 days (not sure how best to do this locally). The second sentence in the latest releases tile should no longer be present (i.e., "we have published _n_ releases...")
4. Remove any featured content you have in your homepage `data.json` in you Zebedee content dir. The In Focus section should then not render at all

### Who can review

Anyone but me
