### PR TITLE
Quick fix for release calendar degradation

### DIFF
--- a/homepage/homepage.go
+++ b/homepage/homepage.go
@@ -35,7 +35,7 @@ var mainFigureMap map[string]MainFigure
 // Handler handles requests to homepage endpoint
 func Handler(rend RenderClient, zcli ZebedeeClient, bcli BabbageClient, icli ImageClient) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string) {
-		handle(w, r, rend, zcli, bcli, icli, accessToken, collectionID, lang )
+		handle(w, r, rend, zcli, bcli, icli, accessToken, collectionID, lang)
 	})
 
 }
@@ -79,6 +79,9 @@ func handle(w http.ResponseWriter, req *http.Request, rend RenderClient, zcli Ze
 	dateFromMonth := weekAgoTime.Format("01")
 	dateFromYear := weekAgoTime.Format("2006")
 	releaseCalResp, err := bcli.GetReleaseCalendar(ctx, userAccessToken, dateFromDay, dateFromMonth, dateFromYear)
+	if err != nil {
+		log.Event(ctx, "error failed to get release calendar data from babbage ", log.ERROR, log.Error(err))
+	}
 	releaseCalModelData := mapper.ReleaseCalendar(releaseCalResp)
 
 	// Get homepage data from Zebedee

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -92,6 +92,15 @@ func MainFigure(ctx context.Context, id, datePeriod, differenceInterval string, 
 }
 
 func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model.ReleaseCalendar {
+	rc := model.ReleaseCalendar{
+		Releases:                         []model.Release{},
+		NumberOfReleases:                 0,
+		NumberOfOtherReleasesInSevenDays: 0,
+	}
+	// No releases found
+	if rawReleaseCalendar.Result.Results == nil {
+		return &rc
+	}
 	releaseResults := *rawReleaseCalendar.Result.Results
 	numReleasesScheduled := rawReleaseCalendar.Result.NumberOfResults
 
@@ -102,11 +111,9 @@ func ReleaseCalendar(rawReleaseCalendar release_calendar.ReleaseCalendar) *model
 	}
 
 	latestReleases := getLatestReleases(releaseResults)
-	rc := model.ReleaseCalendar{
-		Releases:                         latestReleases,
-		NumberOfReleases:                 numReleasesScheduled,
-		NumberOfOtherReleasesInSevenDays: numReleasesScheduled - len(latestReleases),
-	}
+	rc.Releases = latestReleases
+	rc.NumberOfReleases = numReleasesScheduled
+	rc.NumberOfOtherReleasesInSevenDays = numReleasesScheduled - len(latestReleases)
 	return &rc
 }
 


### PR DESCRIPTION
### What

In the 'fun' rush to get the new homepage released error handling and state degradation was told to be put on hold and just get something deployed. State degradation was recently added however the release calendar still has an edge case/condition that was not always handled. This should fix the issue.

If Babbage returns no releases then homepage wouldn't render at all. The page now renders and release calendar with a degraded state.


### How to review

Ensure you have one scheduled publish with last 7 days. (You can create a new one if needed)

Ensure that you see the release calendar on the homepage when everything is running.
<img width="1002" alt="Screenshot 2020-12-08 at 16 31 41" src="https://user-images.githubusercontent.com/47502916/101512791-511fe880-3973-11eb-9cf3-386f9c4eedf6.png">

Kill Babbage then reload the homepage, the page should renderer and a degraded release calendar should be shown 
<img width="964" alt="Screenshot 2020-12-08 at 15 56 00" src="https://user-images.githubusercontent.com/47502916/101507015-ffc12a80-396d-11eb-86cb-2d65fa679f7a.png">

### Who can review

Anyone except me
