### PR TITLE
add model and mapper for around ons content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-homepage-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.8
 	github.com/ONSdigital/dp-frontend-models v1.9.7
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3 h1:nS3ZG3Eql9T68Q0IFehpnqkUy2AFo
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta h1:Wbjibp0/LLoRewWQfmbWw26iKDixw+iiA42OQgRqTQ4=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta/go.mod h1:zN8+84r1tWgyCmypku7JFN63nCMOGTIM26zf5GwHkJ4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.8 h1:vS8J48jGiGZNmMfwWcPA4wje7nNDQah2GYrYkGAjM5g=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.8/go.mod h1:p9Ig0jUJmOXYpsZFZkb+mBeUgNBKoTiTVqHt1kJlVrM=
 github.com/ONSdigital/dp-frontend-models v1.9.7 h1:VRPZa9Z5UkpoDegNZqRiRLGOXSQUCdn05S8EHT1Nb3I=
 github.com/ONSdigital/dp-frontend-models v1.9.7/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
@@ -21,6 +23,8 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
 github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
+github.com/ONSdigital/log.go/v2 v2.0.5 h1:kl2lF0vr3BQDwPTAUcarDvX4Um3uE3fjVRfLoHAarBc=
+github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/ReneKroon/ttlcache v1.7.0 h1:8BkjFfrzVFXyrqnMtezAaJ6AHPSsVV10m6w28N/Fgkk=
 github.com/ReneKroon/ttlcache v1.7.0/go.mod h1:8BGGzdumrIjWxdRx8zpK6L3oGMWvIXdvB2GD1cfvd+I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/homepage/homepage_updater.go
+++ b/homepage/homepage_updater.go
@@ -83,7 +83,22 @@ func (hu *HomepageUpdater) GetHomePageUpdateFor(ctx context.Context, userAccessT
 			mappedFeaturedContent = mapper.FeaturedContent(homepageContent, imageObjects)
 		}
 
-		m := mapper.Homepage(lang, mappedMainFigures, releaseCalModelData, &mappedFeaturedContent, homepageContent.ServiceMessage)
+		var mappedAroundONS []model.Feature
+		if len(homepageContent.AroundONS) > 0 {
+			imageObjects := map[string]image.ImageDownload{}
+			for _, fc := range homepageContent.AroundONS {
+				if fc.ImageID != "" {
+					image, err := hu.clients.ImageAPI.GetDownloadVariant(ctx, userAccessToken, "", "", fc.ImageID, ImageVariant)
+					if err != nil {
+						log.Event(ctx, "error getting image download variant", log.ERROR, log.Error(err), log.Data{"around-ons-entry": fc.Title})
+					}
+					imageObjects[fc.ImageID] = image
+				}
+			}
+			mappedAroundONS = mapper.AroundONS(homepageContent, imageObjects)
+		}
+
+		m := mapper.Homepage(lang, mappedMainFigures, releaseCalModelData, &mappedFeaturedContent, &mappedAroundONS, homepageContent.ServiceMessage)
 
 		b, err := json.Marshal(m)
 		if err != nil {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -146,13 +146,15 @@ func FeaturedContent(homepageData zebedee.HomepageContent, images map[string]ima
 // AroundONS takes the homepageContent as returned from the client and returns an array of featured content
 func AroundONS(homepageData zebedee.HomepageContent, images map[string]image.ImageDownload) []model.Feature {
 	var mappedAroundONS []model.Feature
-	for _, fc := range homepageData.AroundONS {
-		mappedAroundONS = append(mappedAroundONS, model.Feature{
-			Title:       fc.Title,
-			Description: fc.Description,
-			URI:         fc.URI,
-			ImageURL:    images[fc.ImageID].Href,
-		})
+	if len(homepageData.AroundONS) > 0 {
+		for _, fc := range homepageData.AroundONS {
+			mappedAroundONS = append(mappedAroundONS, model.Feature{
+				Title:       fc.Title,
+				Description: fc.Description,
+				URI:         fc.URI,
+				ImageURL:    images[fc.ImageID].Href,
+			})
+		}
 	}
 	return mappedAroundONS
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -36,7 +36,7 @@ type TrendInfo struct {
 var decimalPointDisplayThreshold = decimal.NewFromInt(1000)
 
 // Homepage maps data to our homepage frontend model
-func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, releaseCal *model.ReleaseCalendar, featuredContent *[]model.Feature, serviceMessage string) model.Page {
+func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, releaseCal *model.ReleaseCalendar, featuredContent *[]model.Feature, aroundONS *[]model.Feature,  serviceMessage string) model.Page {
 	var page model.Page
 	page.Type = "homepage"
 	page.Metadata.Title = "Home"
@@ -48,6 +48,7 @@ func Homepage(localeCode string, mainFigures map[string]*model.MainFigure, relea
 	page.Data.MainFigures = mainFigures
 	page.Data.ReleaseCalendar = *releaseCal
 	page.Data.Featured = *featuredContent
+	page.Data.AroundONS = *aroundONS
 	return page
 }
 
@@ -140,6 +141,20 @@ func FeaturedContent(homepageData zebedee.HomepageContent, images map[string]ima
 		})
 	}
 	return mappedFeaturesContent
+}
+
+// AroundONS takes the homepageContent as returned from the client and returns an array of featured content
+func AroundONS(homepageData zebedee.HomepageContent, images map[string]image.ImageDownload) []model.Feature {
+	var mappedAroundONS []model.Feature
+	for _, fc := range homepageData.AroundONS {
+		mappedAroundONS = append(mappedAroundONS, model.Feature{
+			Title:       fc.Title,
+			Description: fc.Description,
+			URI:         fc.URI,
+			ImageURL:    images[fc.ImageID].Href,
+		})
+	}
+	return mappedAroundONS
 }
 
 func getLatestReleases(rawReleases []release_calendar.Results) []model.Release {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -361,6 +361,14 @@ func TestUnitMapper(t *testing.T) {
 			So(aroundONS, ShouldBeNil)
 		})
 
+		Convey("AroundONS handles when no AroundONS data is passed in", func() {
+			mockedTestData := mockedHomepageData
+			mockedTestData.AroundONS = nil
+			mockedImageTestData := map[string]image.ImageDownload{}
+			aroundONS := AroundONS(mockedTestData, mockedImageTestData)
+			So(aroundONS, ShouldBeNil)
+		})
+
 		Convey("FeaturedContent maps mock data to page model correctly", func() {
 			mockedTestData := mockedHomepageData
 			mockedImageTestData := mockedImageDownloadsData

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -217,6 +217,20 @@ func TestUnitMapper(t *testing.T) {
 				ImageID:     "",
 			},
 		},
+		AroundONS: []zebedee.Featured{
+			{
+				Title:       "Around ONS one",
+				Description: "Around ONS one description",
+				URI:         "Around ONS one URI",
+				ImageID:     "123",
+			},
+			{
+				Title:       "Around ONS two",
+				Description: "Around ONS two description",
+				URI:         "Around ONS two URI",
+				ImageID:     "",
+			},
+		},
 		ServiceMessage: "",
 		URI:            "/",
 		Type:           "",
@@ -250,6 +264,21 @@ func TestUnitMapper(t *testing.T) {
 			ImageURL:    "",
 		},
 	}
+
+	var mockedAroundONS = []model.Feature{
+		{
+			Title:       "Around ONS one",
+			Description: "Around ONS one description",
+			URI:         "Around ONS one URI",
+			ImageURL:    "path/to/123.png",
+		},
+		{
+			Title:       "Around ONS two",
+			Description: "Around ONS two description",
+			URI:         "Around ONS two URI",
+			ImageURL:    "",
+		},
+	}
 	var mockedImageDownloadsData = map[string]image.ImageDownload{
 		"123": {
 			Size:  111111,
@@ -274,7 +303,7 @@ func TestUnitMapper(t *testing.T) {
 	serviceMessage := "Test service message"
 
 	Convey("test homepage mapping works", t, func() {
-		page := Homepage("en", mockedMainFigures, &mockedReleaseData, &mockedFeaturedContent, serviceMessage)
+		page := Homepage("en", mockedMainFigures, &mockedReleaseData, &mockedFeaturedContent, &mockedAroundONS, serviceMessage)
 
 		So(page.Type, ShouldEqual, "homepage")
 		So(page.Data.MainFigures["test_id"].Figure, ShouldEqual, mockedMainFigure.Figure)
@@ -283,6 +312,7 @@ func TestUnitMapper(t *testing.T) {
 		So(page.Data.HasFeaturedContent, ShouldEqual, true)
 		So(page.Data.HasMainFigures, ShouldEqual, true)
 		So(len(page.Data.Featured), ShouldEqual, 3)
+		So(len(page.Data.AroundONS), ShouldEqual, 2)
 	})
 
 	Convey("test main figures mapping works", t, func() {
@@ -320,6 +350,31 @@ func TestUnitMapper(t *testing.T) {
 				}
 			}
 			So(featuredContent[2].ImageURL, ShouldEqual, "")
+		})
+	})
+
+	Convey("test AroundONS", t, func() {
+		Convey("AroundONS handles when no homepage data is passed in", func() {
+			mockedTestData := zebedee.HomepageContent{}
+			mockedImageTestData := map[string]image.ImageDownload{}
+			aroundONS := AroundONS(mockedTestData, mockedImageTestData)
+			So(aroundONS, ShouldBeNil)
+		})
+
+		Convey("FeaturedContent maps mock data to page model correctly", func() {
+			mockedTestData := mockedHomepageData
+			mockedImageTestData := mockedImageDownloadsData
+			aroundONS := AroundONS(mockedTestData, mockedImageTestData)
+			So(len(aroundONS), ShouldEqual, 2)
+			for i := 0; i < len(aroundONS); i++ {
+				So(aroundONS[i].Title, ShouldEqual, mockedTestData.AroundONS[i].Title)
+				So(aroundONS[i].Description, ShouldEqual, mockedTestData.AroundONS[i].Description)
+				So(aroundONS[i].URI, ShouldEqual, mockedTestData.AroundONS[i].URI)
+				if aroundONS[i].ImageURL != "" {
+					So(aroundONS[i].ImageURL, ShouldEqual, mockedImageDownloadsData[mockedTestData.AroundONS[i].ImageID].Href)
+				}
+			}
+			So(aroundONS[1].ImageURL, ShouldEqual, "")
 		})
 	})
 
@@ -373,7 +428,7 @@ func TestUnitMapper(t *testing.T) {
 		var mockedNoFeaturedContent []model.Feature
 		var mockedNoMainFigures = make(map[string]*model.MainFigure)
 
-		gracefulDegradationPage := Homepage("en", mockedNoMainFigures, &mockedReleaseData, &mockedNoFeaturedContent, serviceMessage)
+		gracefulDegradationPage := Homepage("en", mockedNoMainFigures, &mockedReleaseData, &mockedNoFeaturedContent, &mockedAroundONS, serviceMessage)
 		So(gracefulDegradationPage.Data.HasFeaturedContent, ShouldEqual, false)
 		So(gracefulDegradationPage.Data.HasMainFigures, ShouldEqual, false)
 	})

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -369,6 +369,25 @@ func TestUnitMapper(t *testing.T) {
 			So(aroundONS, ShouldBeNil)
 		})
 
+		Convey("AroundONS handles when AroundONS data with missing fields is passed in", func() {
+			mockedTestData := mockedHomepageData
+			mockedTestData.AroundONS[1].URI = ""
+			mockedTestData.AroundONS[1].Title = ""
+			mockedTestData.AroundONS[1].Description = ""
+			mockedImageTestData := map[string]image.ImageDownload{}
+			aroundONS := AroundONS(mockedTestData, mockedImageTestData)
+			So(len(aroundONS), ShouldEqual, 2)
+			for i := 0; i < len(aroundONS); i++ {
+				So(aroundONS[i].Title, ShouldEqual, mockedTestData.AroundONS[i].Title)
+				So(aroundONS[i].Description, ShouldEqual, mockedTestData.AroundONS[i].Description)
+				So(aroundONS[i].URI, ShouldEqual, mockedTestData.AroundONS[i].URI)
+				if aroundONS[i].ImageURL != "" {
+					So(aroundONS[i].ImageURL, ShouldEqual, mockedImageDownloadsData[mockedTestData.AroundONS[i].ImageID].Href)
+				}
+			}
+			So(aroundONS[1].ImageURL, ShouldEqual, "")
+		})
+
 		Convey("FeaturedContent maps mock data to page model correctly", func() {
 			mockedTestData := mockedHomepageData
 			mockedImageTestData := mockedImageDownloadsData


### PR DESCRIPTION
### What

Add Around ONS section to homepage edit

### How to review

Get latest zebedee develop branch
Clone the feature/add-edit-ability-to-homepage-around-ons branch in the following repos:
- florence
- dp-frontend-homepage-controller
- dp-frontend-renderer

Run publishing stack locally
Create a new collection in florence CMS and attempt to edit the homepage content.
Should see a new editable list section titled 'Around ONS'
Once some content is added to the section select save and preview
In the preview window the newly added/edited Around ONS content should be displayed in the correct section

### Who can review

Anyone
