### PR TITLE
update refence to library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.17.0
+	github.com/ONSdigital/dp-renderer v1.19.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/ONSdigital/dp-renderer v1.15.0 h1:Jq/5DfokT2OOCVn72skWFyaWTYBe5HNWMP7
 github.com/ONSdigital/dp-renderer v1.15.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.17.0 h1:ZeqHRMVV2Meot55rdyCSBbOxtoMkU3SmFRyXMNMGFx8=
 github.com/ONSdigital/dp-renderer v1.17.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.19.0 h1:W2DWnMHvTw8gReZ0Gf8eJWXogJ7rt8/N8sycHlxaafw=
+github.com/ONSdigital/dp-renderer v1.19.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update homepage controller to latest version of [renderer library](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.19.0) `1.19.0`

### How to review

See that renderer library in go.mod file points to version `1.19.0`

### Who can review

Anyone
