### PR TITLE
update library reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.21.0
+	github.com/ONSdigital/dp-renderer v1.21.1
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/ONSdigital/dp-renderer v1.20.0 h1:LeaxCzxbxxRZl7Kb8XxHGdt5HWphB/Lrxf0
 github.com/ONSdigital/dp-renderer v1.20.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.21.0 h1:lPCX5x8JYmPSafpSOUtikcjgFVZ8jh1N36FNlES7WJA=
 github.com/ONSdigital/dp-renderer v1.21.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.21.1 h1:dSvaby6bIuLGlL4MTBFzQaJFtZgt21X0wbb9DY1I7E8=
+github.com/ONSdigital/dp-renderer v1.21.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update `dp-renderer` library reference to 1.21.1

### How to review

See in `go.mod` file that `dp-renderer` points to version `1.21.1` and that `go.sum` has been updated with this dependency. 

### Who can review

Anyone
