### PR TITLE
fix bug in census banner when using text spacing tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.23.1
+	github.com/ONSdigital/dp-renderer v1.23.2
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/ONSdigital/dp-renderer v1.21.1 h1:dSvaby6bIuLGlL4MTBFzQaJFtZgt21X0wbb
 github.com/ONSdigital/dp-renderer v1.21.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.23.1 h1:sBJ68d3/fbmtPFQC8NWkklAPRBpvaHU1jtJIy0a1Cj0=
 github.com/ONSdigital/dp-renderer v1.23.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.23.2 h1:CinHL361CcJSkf/3uQy2hYCsZFVVWcyJDomDF1m0DJk=
+github.com/ONSdigital/dp-renderer v1.23.2/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update reference to renderer library [v1.23.2](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.23.2) that includes bug fix in census banner when using a text spacing tool

### How to review

See that `go.mod` and `go.sum` have been updated 

### Who can review

Anyone
