### PR TITLE
update census release calendar link, nancy-ignore and bump dp-renderer

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,14 @@
+# Skip for indirect dependency golang/github.com/hashicorp/consul/api@v1.1.0
+# Used by github.com/ONSdigital/dp-cookies v0.3.3
+# For more info: https://ossindex.sonatype.org/vulnerability/CVE-2022-29153?component-type=golang&component-name=github.com%2Fhashicorp%2Fconsul%2Fapi&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.29
+CVE-2022-29153
+
+# Skip for indirect dependency golang/github.com/miekg/dns@v1.0.14
+# Used by github.com/ONSdigital/dp-cookies v0.3.3
+# For more info: https://ossindex.sonatype.org  
+sonatype-2021-1401
+
+# Skip for indirect dependency golang/github.com/pkg/sftp@v1.10.1
+# Used by github.com/ONSdigital/dp-cookies v0.3.3
+# For more info: https://ossindex.sonatype.org  
+sonatype-2019-0890

--- a/assets/templates/census.tmpl
+++ b/assets/templates/census.tmpl
@@ -49,7 +49,7 @@
                 <p id="census-releases-desc">{{ localise "CensusReleasesSubhead" .Language 1 }}</p>
                 <ul class="ons-list ons-list--dashed">
                     <li class="ons-list__item">
-                        <a href="/releasecalendar" class="ons-list__link">{{ localise "CensusReleasesLink1" .Language 1 }}</a>
+                        <a href="/releasecalendar?query=census&fromDateDay=&fromDateMonth=&fromDateYear=&toDateDay=&toDateMonth=&toDateYear=&view=upcoming" class="ons-list__link">{{ localise "CensusReleasesLink1" .Language 1 }}</a>
                     </li>
                     <li class="ons-list__item">
                         <a href="/census/censustransformationprogramme/census2021outputs/releaseplans" class="ons-list__link">

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.25.2
+	github.com/ONSdigital/dp-renderer v1.31.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/ONSdigital/dp-renderer v1.23.3 h1:WQna9FLUGJOoVDOE1CR6G7Ufixl+YMq2esK
 github.com/ONSdigital/dp-renderer v1.23.3/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.25.2 h1:hGYvl2Big/Z9DP+AnTHjIKU+iEgdpenkUMDp4E32sF0=
 github.com/ONSdigital/dp-renderer v1.25.2/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.31.0 h1:/ZHcibRthXcINKrsALmd6Cs7cXxoNa9sGQKlr1Jmm4k=
+github.com/ONSdigital/dp-renderer v1.31.0/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=
@@ -512,6 +514,8 @@ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
### What

- update census release calendar link
- bump renderer version
- add `.nancy-ignore` file

### Who can review

Anyone
