### PR TITLE
use British Summer Time

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ func get() (*Config, error) {
 		IsPublishingMode:           false,
 		Languages:                  "en,cy",
 		SiteDomain:                 "localhost",
-		CensusFirstResults:         "Wednesday, 27-Jul-22 14:29:00 UTC",
+		CensusFirstResults:         "Wednesday, 27-Jul-22 11:00:00 BST", // Use BST as timezone
 	}
 
 	return cfg, envconfig.Process("", cfg)


### PR DESCRIPTION
### What

Update config to use `BST` instead of `UTC` so there is less confusion when setting the time for the Census Results to go live. 

### How to review

See that default config time is now set to `BST`

### Who can review

Anyone.
