### PR TITLE
increase sleep period in shutdown timeout test to reduce probability …

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -302,7 +302,7 @@ func TestClose(t *testing.T) {
 			timeoutServerMock := &mock.HTTPServerMock{
 				ListenAndServeFunc: func() error { return nil },
 				ShutdownFunc: func(ctx context.Context) error {
-					time.Sleep(2 * time.Millisecond)
+					time.Sleep(100 * time.Millisecond)
 					return nil
 				},
 			}


### PR DESCRIPTION
…of context switching preventing the timeout being triggered

### What

The shutdown timeout unit test was randomly failing in the CI.
The cause is that the timeout and sleep periods were too short, and a delay in the context switching may prevent the timeout to be triggered.

In this PR the sleeping period is increased to 100 ms, which will drastically reduce the probability of this happening again.

### How to review

Make sure unit tests pass locally and CI

### Who can review

anyone