### PR TITLE
send subtopic id

### DIFF
--- a/census/census.go
+++ b/census/census.go
@@ -52,7 +52,7 @@ func handle(w http.ResponseWriter, req *http.Request, cfg *config.Config, c cach
 			}
 			availableItems = append(availableItems, model.Topics{
 				Topic: subTopics.Title,
-				URL:   fmt.Sprintf("/search?topics=%s,%s", cfg.CensusTopicID, subTopics.ID),
+				URL:   fmt.Sprintf("/search?topics=%s", subTopics.ID),
 				ID:    subTopics.ID,
 			})
 		}


### PR DESCRIPTION
### What

We should only send the subtopic id from the census topics page. This removes the census id from the params. 

### How to review

See that tests pass and code makes sense. 

### Who can review

Anyone but me.
