### PR TITLE
update references to libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.4.0
 	github.com/ONSdigital/dp-healthcheck v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.6.0
-	github.com/ONSdigital/dp-renderer v1.58.0
+	github.com/ONSdigital/dp-renderer v1.60.0
 	github.com/ONSdigital/dp-topic-api v0.15.0
 	github.com/ONSdigital/log.go v1.1.0
 	github.com/ONSdigital/log.go/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/ONSdigital/dp-net/v2 v2.6.0 h1:orxdb0SVDrJgz/zma0QXgQCAGJdLDhp6g2XqH6
 github.com/ONSdigital/dp-net/v2 v2.6.0/go.mod h1:4/2ZyId//hFa7AtbbRNQctY729C1Vbw4UEdOliRvpZI=
 github.com/ONSdigital/dp-renderer v1.58.0 h1:GBGKiFFtP91Q6XJ4VwYlKUh8LPjpNRNVAaDk1Mkmc0Q=
 github.com/ONSdigital/dp-renderer v1.58.0/go.mod h1:aEgUZoxxw4vy5QG/1WYid3ApbLkaakbyn3/CqIGR/yE=
+github.com/ONSdigital/dp-renderer v1.60.0 h1:Fw7tauRA7b4XIjrPnutiA1Mq8uHjzqua/FNw7c0O/rk=
+github.com/ONSdigital/dp-renderer v1.60.0/go.mod h1:aEgUZoxxw4vy5QG/1WYid3ApbLkaakbyn3/CqIGR/yE=
 github.com/ONSdigital/dp-topic-api v0.15.0 h1:I7tWhUnx2ufqaaqDd/n4qAUAKX1Y7iDwVx2DORwrj7M=
 github.com/ONSdigital/dp-topic-api v0.15.0/go.mod h1:QDnwETsWELwCSK1yHj1VgYAxhgU3LpBC8Xu4WHPglcI=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -58,7 +58,7 @@ func Homepage(cfg config.Config, localeCode string, basePage coreModel.Page, mai
 	page.Language = localeCode
 	page.Data.MainFigures = mainFigures
 	page.EmergencyBanner = mapEmergencyBanner(emergencyBannerContent)
-	page.FeatureFlags.SixteensVersion = "8466e33"
+	page.FeatureFlags.SixteensVersion = "3de3b17"
 	if navigationContent != nil {
 		page.NavigationContent = mapNavigationContent(*navigationContent)
 	}


### PR DESCRIPTION
### What

Update to latest references to sixteens and `dp-renderer` which contain changes to the feedback template/styling. 

### How to review

See that sixteens reference matches [this](https://github.com/ONSdigital/sixteens/releases/tag/v1.5.1) and dp-renderer reference matches [this](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.60.0) 

### Who can review

!me
