### PR TITLE
remove historic census from hub

### DIFF
--- a/census/census.go
+++ b/census/census.go
@@ -46,8 +46,8 @@ func handle(w http.ResponseWriter, req *http.Request, cfg *config.Config, c cach
 
 		var availableItems []model.Topics
 		for _, subTopics := range items {
-			// do not map "Equalities" since there are no results for this topic
-			if subTopics.Title == "Equalities" {
+			// do not map "Equalities" or "Historic census" since there are no results for these topics
+			if subTopics.Title == "Equalities" || subTopics.Title == "Historic census" {
 				continue
 			}
 			availableItems = append(availableItems, model.Topics{


### PR DESCRIPTION
### What

"Historic census" should be removed from the census hub because there are 0 results for this topic. 

### How to review

See that "Historic census" is no longer on the census hub. 
<img width="1100" alt="Screenshot 2023-03-21 at 13 18 20" src="https://user-images.githubusercontent.com/16807393/226619322-5c2b7dcb-fef1-4d40-ade9-89e6e4ec6c6c.png">


### Who can review

!me
