### PR TITLE
Remove URL params following topic flattening

### DIFF
--- a/assets/templates/partials/cards/census-data.tmpl
+++ b/assets/templates/partials/cards/census-data.tmpl
@@ -6,7 +6,7 @@
             <ul class="ons-list ons-list--dashed">
                 <li class="ons-list__item">
                     {{ if .Data.DatasetFinderEnabled }}
-                        <a href="/census/find-a-dataset{{ .Data.GetCensusDataURLQuery }}" class="ons-list__link">{{ localise "GetCensusDataLink1" .Language 1 }}</a>
+                        <a href="/census/find-a-dataset" class="ons-list__link">{{ localise "GetCensusDataLink1" .Language 1 }}</a>
                     {{ else }}
                         <a href="/search{{ .Data.GetCensusDataURLQuery }}" class="ons-list__link">{{ localise "GetCensusDataLink1" .Language 1 }}</a>
                     {{ end }} 


### PR DESCRIPTION
### What

Remove topic query params from find a dataset following topic flattening. 

### How to review

Load homepage-controller with EnableGetDataCard: true, DatasetFinderEnabled: true, EnableCensusTopicSubsection: true. 

With search controller as well and see it take you to the census/find-a-dataset without topics pre-selected. 

### Who can review

Not me. 