### PR TITLE
Fix local docker build

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-bullseye AS base
+FROM golang:1.23.2-bullseye AS base
 
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London PATH=$PATH:$GOPATH/bin
 


### PR DESCRIPTION
### What

Local docker go version was out of step with the version in go.mod and the CI files. This was causing the dp-compose stack to fail. Matching the version to the version specified in the CI files to fix the build and ensure consistency.

### How to review

Ensure the Dockerfile.local go version matches the version used by CI (i.e. `ci/*.yml`).

### Who can review

!me