### PR TITLE
Prview site link opens new tab

### DIFF
--- a/assets/templates/homepage/preview-site-tile.tmpl
+++ b/assets/templates/homepage/preview-site-tile.tmpl
@@ -9,7 +9,7 @@
                 {{ localise "PreviewSiteText" .Language 1 }}
             <br>
         </div>
-        <a href={{ .Data.PreviewSiteURL }} class="tile__link--icon" data-test="preview-site-link">
+        <a href={{ .Data.PreviewSiteURL }} class="tile__link--icon" data-test="preview-site-link" target="_blank" rel="noopener">
             <span class="text--white font-weight-400 underline-link">{{ localise "PreviewSiteLink" .Language 1 }}</span>
             <svg class="tile__link-icon" width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g id="icon-external-link">


### PR DESCRIPTION
### What

This was to make the link on preview site tile open in new tab.

### How to review

Can see setup [here](https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/242)

Opens in new tab.
Sense check.
Tests pass.

### Who can review

Anyone
