### PR TITLE
Bump to go 1.26.2

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,0 +1,7 @@
+ignore:
+  - id: GO-2026-4883
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.
+  - id: GO-2026-4887
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-frontend-homepage-controller

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-chrome-go
-    tag: 1.26.1-bookworm-googlechromestablelatest
+    tag: 1.26.2-bookworm-googlechromestablelatest
 
 inputs:
   - name: dp-frontend-homepage-controller

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.1-bookworm-golangci-lint-2
+    tag: 1.26.2-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-frontend-homepage-controller

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-frontend-homepage-controller


### PR DESCRIPTION
### What

Bump go version to 1.26.2
ignored vulnerabilities for now as they're used for testing

### How to review

Sense check
Ensure tests pass

### Who can review

Not me