### PR TITLE
Change version of dp-api-clients-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/ONSdigital/dis-design-system-go v1.4.0
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0
 	github.com/ONSdigital/dp-cache v0.6.1
 	github.com/ONSdigital/dp-component-test v1.4.4-alpha
 	github.com/ONSdigital/dp-cookies v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ONSdigital/dis-design-system-go v1.4.0 h1:mo6fnQ6q09BJHgBSVtptokyIUwhy0EvaeoiStDGaqYw=
 github.com/ONSdigital/dis-design-system-go v1.4.0/go.mod h1:r6bXYLXydqNMpYDKcz6CKaVH2Kbq3XIxMyGlbicE0Xc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0 h1:wJ+lfVqF7rDksQ+p6adHqoXvE0Q/4ZDfifxzLC16Vh8=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0 h1:iCn+HYkqYDTrzBuwDuvbUYCrIpOrRcVaRsMaATEpxJs=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-authorisation/v2 v2.32.2 h1:Hxza+cvvPb2zvZfEOpZfWZcy/7MjIoRPHAY0fd9rng8=
 github.com/ONSdigital/dp-authorisation/v2 v2.32.2/go.mod h1:uDDkQ/HeqeirqXBCVrvyGxbKSO/bKe80wW7V226sB+g=
 github.com/ONSdigital/dp-cache v0.6.1 h1:wiYvxRIef9nu3Uk1//il5vNLTeKgajZ2kYacwkF4Xig=


### PR DESCRIPTION
### What

Change version of dp-api-clients-go to 2.273.0 as [per](https://onswebsite.slack.com/archives/C051DH0CPT3/p1776245418494579?thread_ts=1776077570.127689&cid=C051DH0CPT3) 

### How to review

Sense check

### Who can review

Not me